### PR TITLE
[chore] Docker 빌드 및 OCI 자동 배포 CI/CD 파이프라인 구축

### DIFF
--- a/.github/workflows.deploy.yml
+++ b/.github/workflows.deploy.yml
@@ -1,0 +1,118 @@
+name: OCI VM에 Docker로 배포
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  DOCKER_IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/skhu-capstone
+  OCI_HOST: ${{ secrets.OCI_HOST }}
+  OCI_SSH_USER: ubuntu
+  PRIVATE_KEY: ${{ secrets.OCI_SSH_PRIVATE_KEY }}
+  CONTAINER_NAME: skhu-capstone
+  APP_PORT: "8080"
+  TZ_REGION: "Asia/Seoul"
+
+jobs:
+  build-and-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Set up JDK 21 with Gradle cache
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Set up configuration files
+        run: |
+          mkdir -p ./src/main/resources
+          cat > ./src/main/resources/application.yml <<'EOF'
+          ${{ secrets.APPLICATION_YML }}
+          EOF
+          cat > ./src/main/resources/application-dev.yml <<'EOF'
+          ${{ secrets.APPLICATION_DEV_YML }}
+          EOF
+          cat > ./src/main/resources/application-prod.yml <<'EOF'
+          ${{ secrets.APPLICATION_PROD_YML }}
+          EOF
+
+      - name: Verify config files exist
+        run: ls -l ./src/main/resources/application*.yml
+
+      - name: Build with Gradle
+        run: ./gradlew clean build --no-daemon --warning-mode=all -x test
+
+      - name: Set image tags
+        id: meta
+        run: |
+          SHA_TAG=${GITHUB_SHA::7}
+          echo "sha_tag=$SHA_TAG" >> $GITHUB_OUTPUT
+          echo "latest_tag=latest" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.meta.outputs.latest_tag }}
+            ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.meta.outputs.sha_tag }}
+
+  deploy-to-oci:
+    needs: build-and-push-docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to OCI VM
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ env.OCI_HOST }}
+          username: ${{ env.OCI_SSH_USER }}
+          key: ${{ env.PRIVATE_KEY }}
+          script: |
+            set -euo pipefail
+            IMAGE="${{ env.DOCKER_IMAGE_NAME }}:latest"
+            NAME="${{ env.CONTAINER_NAME }}"
+            PORT="${{ env.APP_PORT }}"
+            TZ="${{ env.TZ_REGION }}"
+
+            echo "[1/5] Pull latest image"
+            sudo docker pull "$IMAGE"
+
+            echo "[2/5] Stop & remove existing container (if exists)"
+            if sudo docker ps -a --format '{{.Names}}' | grep -wq "$NAME"; then
+              sudo docker stop "$NAME" || true
+              sudo docker rm "$NAME" || true
+            fi
+
+            echo "[3/5] Run new container on port ${PORT}"
+            sudo docker run -d \
+              --name "$NAME" \
+              -p ${PORT}:${PORT} \
+              -e TZ="$TZ" \
+              -e SPRING_PROFILES_ACTIVE=prod \
+              --restart unless-stopped \
+              "$IMAGE"
+
+            echo "[4/5] Cleanup dangling images"
+            sudo docker image prune -f
+
+            echo "[5/5] Check running container"
+            sudo docker ps
+            echo "Deployment complete: $NAME running on port $PORT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM amazoncorretto:21
+ARG JAR_FILE=build/libs/*.jar
+WORKDIR /app
+COPY ${JAR_FILE} app.jar
+EXPOSE 8080
+RUN ln -snf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && echo 'Asia/Seoul' > /etc/timezone
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]


### PR DESCRIPTION
## 관련 이슈
#1 

## 작업 내용

### Dockerfile 추가
- Java 21 (Amazon Corretto) 기반 이미지 설정
- 빌드된 JAR 파일을 컨테이너 이미지로 패키징
- 포트 8080 노출
- 타임존 Asia/Seoul 설정

### CI/CD 파이프라인 구축 (.github/workflows/deploy.yml)
- main 브랜치 push 시 자동 배포 트리거
- JDK 21 환경 세팅 및 Gradle 빌드
- GitHub Secrets 기반 application.yml 설정 파일 주입
- Docker Hub에 이미지 빌드 및 push (latest + SHA 태그)
- SSH를 통해 OCI VM에 접속하여 최신 이미지 배포
- 기존 컨테이너 중단 및 새 컨테이너 무중단 교체
- 배포 후 dangling 이미지 자동 정리

## 배포 흐름
main push → Gradle 빌드 → Docker 이미지 빌드 → Docker Hub push → OCI VM SSH 접속 → 컨테이너 교체

## 추가 사항
- 민감 정보는 GitHub Secrets로 관리하여 코드에 노출되지 않도록 처리