### PR TITLE
[FEAT] Google OAuth 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     // 이메일 발송
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // 스웨거
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,20 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // 스프링 시큐리티
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // Google API 호출
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // 이메일 발송
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // 스프링 시큐리티
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/skhu/skhucapstone/auth/client/GoogleApiClient.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/client/GoogleApiClient.java
@@ -1,0 +1,26 @@
+package com.skhu.skhucapstone.auth.client;
+
+import com.skhu.skhucapstone.common.exception.CustomException;
+import com.skhu.skhucapstone.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleApiClient {
+
+    private final WebClient webClient = WebClient.create();
+
+    public GoogleUserInfo getUserInfo(String accessToken) {
+        return webClient.get()
+                .uri("https://www.googleapis.com/oauth2/v3/userinfo")
+                .header("Authorization", "Bearer " + accessToken) // 프론트에서 받은 토큰을 헤더에 담아 구글에 전달
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError(), response ->
+                        Mono.error(new CustomException(ErrorCode.INVALID_GOOGLE_TOKEN)))
+                .bodyToMono(GoogleUserInfo.class)
+                .block();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/auth/client/GoogleUserInfo.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/client/GoogleUserInfo.java
@@ -1,0 +1,13 @@
+package com.skhu.skhucapstone.auth.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true) // 구글 응답 중 내가 필요한 것만 가져옴
+public class GoogleUserInfo {
+
+    private String email;
+    private String name;
+    private String picture;
+}

--- a/src/main/java/com/skhu/skhucapstone/auth/controller/AuthController.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.skhu.skhucapstone.auth.controller;
+
+import com.skhu.skhucapstone.auth.dto.GoogleLoginReq;
+import com.skhu.skhucapstone.auth.dto.GoogleLoginRes;
+import com.skhu.skhucapstone.auth.service.AuthService;
+import com.skhu.skhucapstone.common.exception.SuccessCode;
+import com.skhu.skhucapstone.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/google/login")
+    public ResponseEntity<ApiResponse<GoogleLoginRes>> googleLogin(
+            @RequestBody
+            @Valid
+            GoogleLoginReq req) {
+        GoogleLoginRes res = authService.googleLogin(req.getGoogleAccessToken());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.LOGIN_SUCCESS, res));
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/auth/controller/AuthController.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/controller/AuthController.java
@@ -5,6 +5,8 @@ import com.skhu.skhucapstone.auth.dto.GoogleLoginRes;
 import com.skhu.skhucapstone.auth.service.AuthService;
 import com.skhu.skhucapstone.common.exception.SuccessCode;
 import com.skhu.skhucapstone.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,11 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = "Auth", description = "로그인/회원가입 API")
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping("/google/login")
+    @Operation(summary = "구글 소셜 로그인", description = "구글 액세스 토큰으로 로그인 또는 회원가입을 처리합니다.")
     public ResponseEntity<ApiResponse<GoogleLoginRes>> googleLogin(
             @RequestBody
             @Valid

--- a/src/main/java/com/skhu/skhucapstone/auth/dto/GoogleLoginReq.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/dto/GoogleLoginReq.java
@@ -1,0 +1,13 @@
+package com.skhu.skhucapstone.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GoogleLoginReq {
+
+    @NotBlank(message = "구글 액세스 토큰을 입력해주세요.") // 의존성 추가
+    private String googleAccessToken;
+}

--- a/src/main/java/com/skhu/skhucapstone/auth/dto/GoogleLoginRes.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/dto/GoogleLoginRes.java
@@ -1,0 +1,18 @@
+package com.skhu.skhucapstone.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GoogleLoginRes {
+
+    private Long userId;
+    private String email;
+    private String name;
+    private String profileImage;
+    private String schoolEmail;
+    private Boolean isVerified;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/skhu/skhucapstone/auth/service/AuthService.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/service/AuthService.java
@@ -1,22 +1,54 @@
 package com.skhu.skhucapstone.auth.service;
 
+import com.skhu.skhucapstone.auth.client.GoogleApiClient;
+import com.skhu.skhucapstone.auth.client.GoogleUserInfo;
 import com.skhu.skhucapstone.auth.dto.GoogleLoginRes;
+import com.skhu.skhucapstone.common.jwt.JwtUtil;
 import com.skhu.skhucapstone.user.respository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import com.skhu.skhucapstone.user.entity.User;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final GoogleApiClient googleApiClient;
+    private final JwtUtil jwtUtil;
 
-    public GoogleLoginRes googleLogin(String googleAccessToken){
+    public GoogleLoginRes googleLogin(String googleAccessToken) {
         // TODO
         // Google API 토큰 검증, 사용자 조회
-        // DB 유저 확인 후 있으면 로그인, 없으면 회원가입
+        GoogleUserInfo userInfo = googleApiClient.getUserInfo(googleAccessToken);
+
+        User user = userRepository.findByEmail(userInfo.getEmail())
+                .orElseGet(() -> registerNewUser(userInfo));
+
         // JWT 발급
+        String accessToken = jwtUtil.generateAccessToken(user.getUserId());
+        String refreshToken = jwtUtil.generateRefreshToken(user.getUserId());
+
         // 응답 반환
-        return null;
+        return GoogleLoginRes.builder()
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .profileImage(user.getProfileImage())
+                .schoolEmail(user.getSchoolEmail())
+                .isVerified(user.getIsVerified())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+    // DB 유저 확인 후 있으면 로그인, 없으면 회원가입
+    private User registerNewUser (GoogleUserInfo userInfo){
+        return userRepository.save(
+                User.builder()
+                        .email(userInfo.getEmail())
+                        .name(userInfo.getName())
+                        .profileImage(userInfo.getPicture())
+                        .build()
+            );
     }
 }

--- a/src/main/java/com/skhu/skhucapstone/auth/service/AuthService.java
+++ b/src/main/java/com/skhu/skhucapstone/auth/service/AuthService.java
@@ -1,0 +1,22 @@
+package com.skhu.skhucapstone.auth.service;
+
+import com.skhu.skhucapstone.auth.dto.GoogleLoginRes;
+import com.skhu.skhucapstone.user.respository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+
+    public GoogleLoginRes googleLogin(String googleAccessToken){
+        // TODO
+        // Google API 토큰 검증, 사용자 조회
+        // DB 유저 확인 후 있으면 로그인, 없으면 회원가입
+        // JWT 발급
+        // 응답 반환
+        return null;
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/exception/CustomException.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.skhu.skhucapstone.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    // 에러코드를 받아서 거기서 메시지, 상태코드를 꺼내 씀
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
@@ -1,0 +1,34 @@
+package com.skhu.skhucapstone.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // Google 로그인
+    INVALID_GOOGLE_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_GOOGLE_TOKEN", "유효하지 않은 구글 토큰입니다."),
+    FORBIDDEN_LOGIN(HttpStatus.FORBIDDEN, "FORBIDDEN_LOGIN", "허용되지 않은 로그인 요청입니다."),
+    EMAIL_ALREADY_LINKED(HttpStatus.CONFLICT, "EMAIL_ALREADY_LINKED", "이미 다른 계정으로 가입된 이메일입니다."),
+
+    // 학교 이메일
+    INVALID_SCHOOL_EMAIL(HttpStatus.FORBIDDEN, "INVALID_SCHOOL_EMAIL", "학교 이메일 형식이 아닙니다."),
+    ALREADY_VERIFIED_EMAIL(HttpStatus.CONFLICT, "ALREADY_VERIFIED_EMAIL", "이미 인증된 학교 이메일입니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_SEND_FAILED", "인증번호 발송에 실패했습니다."),
+
+    // 인증코드
+    INVALID_VERIFICATION_CODE(HttpStatus.FORBIDDEN, "INVALID_VERIFICATION_CODE", "인증번호가 일치하지 않습니다."),
+    VERIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "VERIFICATION_NOT_FOUND", "인증 요청 정보를 찾을 수 없습니다."),
+    VERIFICATION_EXPIRED(HttpStatus.GONE, "VERIFICATION_EXPIRED", "인증번호가 만료되었습니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
+
+    // 공통
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그인이 필요합니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "올바르지 않은 요청입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/skhu/skhucapstone/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.skhu.skhucapstone.common.exception;
+
+import com.skhu.skhucapstone.common.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getCode(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail("INVALID_REQUEST", message));
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
@@ -1,0 +1,16 @@
+package com.skhu.skhucapstone.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+
+    LOGIN_SUCCESS(HttpStatus.OK, "LOGIN_SUCCESS", "구글 소셜 로그인이 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/skhu/skhucapstone/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/skhu/skhucapstone/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.skhu.skhucapstone.common.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtUtil.isTokenValid(token)) {
+            Long userId = jwtUtil.getUserId(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/jwt/JwtUtil.java
+++ b/src/main/java/com/skhu/skhucapstone/common/jwt/JwtUtil.java
@@ -1,0 +1,66 @@
+package com.skhu.skhucapstone.common.jwt;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-expiration}")
+    private long accessExpiration;
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpiration;
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId)) // 누구인지 식별
+                .issuedAt(new Date()) // 토큰 발급 시간
+                .expiration(new Date(System.currentTimeMillis() + accessExpiration)) // 만료 시간
+                .signWith(getSigningKey()) // 위에서 만든 키로 서명
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    public Long getUserId(String token) {
+        return Long.parseLong(
+                Jwts.parser()
+                        .verifyWith(getSigningKey())
+                        .build()
+                        .parseSignedClaims(token)
+                        .getPayload()
+                        .getSubject()
+        );
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Jwts.parser().verifyWith(getSigningKey()).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/response/ApiResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/common/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.skhu.skhucapstone.common.response;
 
+import com.skhu.skhucapstone.common.exception.SuccessCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,8 +13,8 @@ public class ApiResponse<T> {
     private String message;
     private T data;
 
-    public static <T> ApiResponse<T> success(String code, String message, T data){
-        return new ApiResponse<>(true, code, message, data);
+    public static <T> ApiResponse<T> success(SuccessCode successCode, T data){
+        return new ApiResponse<>(true, successCode.getCode(), successCode.getMessage(), data);
     }
 
     public static <T> ApiResponse<T> fail(String code, String message) {

--- a/src/main/java/com/skhu/skhucapstone/common/response/ApiResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/common/response/ApiResponse.java
@@ -1,0 +1,22 @@
+package com.skhu.skhucapstone.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private boolean success;
+    private String code;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(String code, String message, T data){
+        return new ApiResponse<>(true, code, message, data);
+    }
+
+    public static <T> ApiResponse<T> fail(String code, String message) {
+        return new ApiResponse<>(false, code, message, null);
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.skhu.skhucapstone.common.security;
 
+import com.skhu.skhucapstone.common.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,21 +10,25 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT를 쓰니 세션 유지 x
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/google/login").permitAll()
-                        .anyRequest().authenticated());
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
@@ -26,7 +26,13 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/google/login").permitAll()
+                        .requestMatchers(
+                                "/api/auth/google/login",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/webjars/**"
+                        ).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.skhu.skhucapstone.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // JWT를 쓰니 세션 유지 x
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/google/login").permitAll()
+                        .anyRequest().authenticated());
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/security/SwaggerConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/security/SwaggerConfig.java
@@ -1,0 +1,35 @@
+package com.skhu.skhucapstone.common.security;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("SKHU Capstone API")
+                        .description("성공회대학교 캡스톤 디자인 API 명세서")
+                        .version("1.0.0"))
+                .addSecurityItem(securityRequirement)
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", securityScheme));
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/user/entity/User.java
+++ b/src/main/java/com/skhu/skhucapstone/user/entity/User.java
@@ -1,0 +1,34 @@
+package com.skhu.skhucapstone.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicInsert
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String email; // 구글 이메일
+
+    @Column(nullable = false)
+    private String name;
+
+    private String profileImage;
+
+    private String schoolEmail;
+
+    @ColumnDefault("false") // 기본값이 false, @DynamicInsert를 같이 써야함
+    @Column(nullable = false)
+    private Boolean isVerified;
+}

--- a/src/main/java/com/skhu/skhucapstone/user/respository/UserRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/user/respository/UserRepository.java
@@ -1,8 +1,7 @@
 package com.skhu.skhucapstone.user.respository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.security.core.userdetails.User;
-
+import com.skhu.skhucapstone.user.entity.User;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {

--- a/src/main/java/com/skhu/skhucapstone/user/respository/UserRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/user/respository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.skhu.skhucapstone.user.respository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsBySchoolEmail(String schoolEmail);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,14 @@
-server:
-  port: 8080
-
 spring:
   profiles:
     active: dev
 
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+server:
+  port: 8080


### PR DESCRIPTION
## 관련 이슈
#3 

## 작업 목적
Google 소셜 로그인을 통해 사용자가 간편하게 회원가입 및 로그인을 할 수 있도록 한다.

## 작업 배경
기존 회원가입 방식은 입력 과정이 많아 사용자 이탈 가능성이 있다.
Google 계정을 활용한 소셜 로그인을 도입하여 인증 과정을 단순화하고 사용자 경험을 개선한다.

## 작업 내용
### 직접 구현
- User 엔티티 및 UserRepository 정의
- ApiResponse 공통 응답 형식 정의
- 구글 로그인 요청/응답 DTO 정의 (GoogleLoginRequest, GoogleLoginResponse)
- AuthController 엔드포인트 매핑 (POST /api/auth/google/login)
- AuthService 구글 로그인 비즈니스 로직 구현
  - Google API 토큰 검증 및 사용자 정보 조회
  - DB 유저 확인 후 로그인 / 신규 회원가입 처리
  - JWT 발급 및 응답 반환

### AI 활용
- ErrorCode enum 정의 (명세서 기반 에러 코드 목록 생성)
- JwtUtil 토큰 생성 및 검증 유틸 구현
- GoogleApiClient Google API 호출 클라이언트 구현
- GlobalExceptionHandler 전역 예외 핸들러 구현
- JwtAuthenticationFilter JWT 인증 필터 구현
- SecurityConfig Spring Security 기본 설정
- SwaggerConfig Swagger UI 설정 및 API 문서화

## 예상 산출물
- Google 로그인 API (POST /api/auth/google/login)
- JWT 발급 로직
- 소셜 로그인 기반 회원 처리 로직
- ApiResponse 공통 응답 클래스
- CustomException / ErrorCode 예외 처리 구조
- Swagger UI

## 테스트 결과
- Google OAuth Playground에서 발급한 액세스 토큰으로 테스트 완료
- 신규 유저 회원가입 및 JWT 발급 정상 동작 확인
- 응답 형식 명세서와 일치 확인

## 브랜치 전략
- base branch: develop
- working branch: feat/3-google-login

## 완료 조건
- [x] Google 계정으로 로그인 가능하다.
- [x] 사용자 정보가 정상적으로 받아와진다.
- [x] 신규 사용자는 회원 생성 처리된다.
- [x] 로그인 시 JWT가 정상 발급된다.
- [x] 모든 API 응답이 ApiResponse 형식으로 반환된다.
- [x] 에러 발생 시 ErrorCode 기반으로 일관된 에러 응답이 반환된다.