### PR TITLE
Feat/5 club entity

### DIFF
--- a/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
+++ b/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
@@ -1,30 +1,45 @@
 package com.skhu.skhucapstone.club.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "club")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Club {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "club_id")
     private Long id;
 
+    @Column(name = "club_name", nullable = false, length = 100)
     private String clubName;
 
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
 
+    @Column(name = "is_approved", nullable = false)
     private boolean isApproved;
 
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-
+    @Builder
     public Club(String clubName, String description) {
         this.clubName = clubName;
         this.description = description;
@@ -33,15 +48,19 @@ public class Club {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void update(String clubName, String description) {
-        this.clubName = clubName;
-        this.description = description;
+    public void approve() {
+        this.isApproved = true;
         this.updatedAt = LocalDateTime.now();
     }
 
+    public void reject() {
+        this.isApproved = false;
+        this.updatedAt = LocalDateTime.now();
+    }
 
-    public void setApproveStatus(boolean status) {
-        this.isApproved = status;
+    public void updateInfo(String clubName, String description) {
+        this.clubName = clubName;
+        this.description = description;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
+++ b/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
@@ -1,0 +1,47 @@
+package com.skhu.skhucapstone.club.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Club {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String clubName;
+
+    private String description;
+
+    private boolean isApproved;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+
+    public Club(String clubName, String description) {
+        this.clubName = clubName;
+        this.description = description;
+        this.isApproved = false;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void update(String clubName, String description) {
+        this.clubName = clubName;
+        this.description = description;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+    public void setApproveStatus(boolean status) {
+        this.isApproved = status;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubJoinStatus.java
+++ b/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubJoinStatus.java
@@ -1,0 +1,6 @@
+package com.skhu.skhucapstone.clubmember.domain;
+
+public enum ClubJoinStatus {
+    NONE,
+    JOINED
+}

--- a/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubMember.java
+++ b/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubMember.java
@@ -1,40 +1,67 @@
 package com.skhu.skhucapstone.clubmember.domain;
 
 import com.skhu.skhucapstone.club.domain.Club;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "club_member")
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ClubMember {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "club_member_id")
     private Long id;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
     private ClubRole role;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "club_join_status", nullable = false)
+    private ClubJoinStatus clubJoinStatus;
+
+    @Column(name = "joined_at")
     private LocalDateTime joinedAt;
 
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    @ManyToOne
-    @JoinColumn(name = "club_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
     private Club club;
 
+
+    @Column(name = "user_id", nullable = false)
     private Long userId; //아직 유저 엔티티가 없음
 
 
+    @Builder
     public ClubMember(Club club, Long userId, ClubRole role) {
         this.club = club;
         this.userId = userId;
         this.role = role;
+        this.clubJoinStatus = ClubJoinStatus.JOINED;
         this.joinedAt = LocalDateTime.now();
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
@@ -43,6 +70,11 @@ public class ClubMember {
 
     public void changeRole(ClubRole role) {
         this.role = role;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void withdraw() {
+        this.clubJoinStatus = ClubJoinStatus.NONE;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubMember.java
+++ b/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubMember.java
@@ -1,6 +1,7 @@
 package com.skhu.skhucapstone.clubmember.domain;
 
 import com.skhu.skhucapstone.club.domain.Club;
+import com.skhu.skhucapstone.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -51,22 +52,20 @@ public class ClubMember {
     @JoinColumn(name = "club_id", nullable = false)
     private Club club;
 
-
-    @Column(name = "user_id", nullable = false)
-    private Long userId; //아직 유저 엔티티가 없음
-
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Builder
-    public ClubMember(Club club, Long userId, ClubRole role) {
+    public ClubMember(Club club, User user, ClubRole role) {
         this.club = club;
-        this.userId = userId;
+        this.user = user;
         this.role = role;
         this.clubJoinStatus = ClubJoinStatus.JOINED;
         this.joinedAt = LocalDateTime.now();
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
-
 
     public void changeRole(ClubRole role) {
         this.role = role;

--- a/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubMember.java
+++ b/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubMember.java
@@ -1,0 +1,48 @@
+package com.skhu.skhucapstone.clubmember.domain;
+
+import com.skhu.skhucapstone.club.domain.Club;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ClubMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ClubRole role;
+
+    private LocalDateTime joinedAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "club_id")
+    private Club club;
+
+    private Long userId; //아직 유저 엔티티가 없음
+
+
+    public ClubMember(Club club, Long userId, ClubRole role) {
+        this.club = club;
+        this.userId = userId;
+        this.role = role;
+        this.joinedAt = LocalDateTime.now();
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+
+    public void changeRole(ClubRole role) {
+        this.role = role;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubRole.java
+++ b/src/main/java/com/skhu/skhucapstone/clubmember/domain/ClubRole.java
@@ -1,0 +1,7 @@
+package com.skhu.skhucapstone.clubmember.domain;
+
+public enum ClubRole {
+    MEMBER,
+    STAFF,
+    PRESIDENT
+}


### PR DESCRIPTION
## 작업 내용
- Club 엔티티 생성
- ClubMember 엔티티 생성
- ClubRole enum 생성
- ClubJoinStatus enum 생성
- User 엔티티와 연관관계 연결
- 동아리/멤버 구조 기반 도메인 설계 완료
- 
## 주요 구현 사항
- Club: 동아리 기본 정보(이름, 설명, 승인 여부 등) 관리
- ClubMember: 사용자와 동아리의 소속 관계 및 권한 관리
- ClubRole을 통해 대표, 운영진, 일반 부원 권한 구분
- ClubJoinStatus를 통해 가입 상태 관리
- 추후 동아리 생성, 승인, 게시물, 협업 모집 기능 확장을 고려한 구조로 설계