### PR TITLE
Feat/11 club api

### DIFF
--- a/src/main/java/com/skhu/skhucapstone/club/api/ClubController.java
+++ b/src/main/java/com/skhu/skhucapstone/club/api/ClubController.java
@@ -1,0 +1,32 @@
+package com.skhu.skhucapstone.club.api;
+
+import com.skhu.skhucapstone.club.api.dto.Request.ClubCreateRequest;
+import com.skhu.skhucapstone.club.api.dto.Response.ClubResponse;
+import com.skhu.skhucapstone.club.application.ClubService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/clubs")
+@RequiredArgsConstructor
+public class ClubController {
+
+    private final ClubService clubService;
+
+    @PostMapping
+    public ClubResponse createClub(@RequestBody ClubCreateRequest request) {
+        return clubService.createClub(request);
+    }
+
+    @GetMapping
+    public List<ClubResponse> getClubs() {
+        return clubService.getClubs();
+    }
+
+    @GetMapping("/{clubId}")
+    public ClubResponse getClub(@PathVariable Long clubId) {
+        return clubService.getClub(clubId);
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/club/api/ClubController.java
+++ b/src/main/java/com/skhu/skhucapstone/club/api/ClubController.java
@@ -3,6 +3,7 @@ package com.skhu.skhucapstone.club.api;
 import com.skhu.skhucapstone.club.api.dto.Request.ClubCreateRequest;
 import com.skhu.skhucapstone.club.api.dto.Response.ClubResponse;
 import com.skhu.skhucapstone.club.application.ClubService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,7 +17,7 @@ public class ClubController {
     private final ClubService clubService;
 
     @PostMapping
-    public ClubResponse createClub(@RequestBody ClubCreateRequest request) {
+    public ClubResponse createClub(@Valid @RequestBody ClubCreateRequest request) {
         return clubService.createClub(request);
     }
 

--- a/src/main/java/com/skhu/skhucapstone/club/api/dto/Request/ClubCreateRequest.java
+++ b/src/main/java/com/skhu/skhucapstone/club/api/dto/Request/ClubCreateRequest.java
@@ -1,7 +1,29 @@
 package com.skhu.skhucapstone.club.api.dto.Request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record ClubCreateRequest(
+        @NotBlank
         String clubName,
-        String description
+
+        @NotBlank
+        String category,
+
+        @NotBlank @Size(max = 255)
+        String shortDescription,
+
+        @NotBlank
+        String detailDescription,
+
+        String imageUrl,
+
+        @NotBlank
+        String regularMeetingTime,
+
+        @NotBlank
+        String activityLocation,
+
+        @NotBlank String contact
 ) {
 }

--- a/src/main/java/com/skhu/skhucapstone/club/api/dto/Request/ClubCreateRequest.java
+++ b/src/main/java/com/skhu/skhucapstone/club/api/dto/Request/ClubCreateRequest.java
@@ -1,0 +1,7 @@
+package com.skhu.skhucapstone.club.api.dto.Request;
+
+public record ClubCreateRequest(
+        String clubName,
+        String description
+) {
+}

--- a/src/main/java/com/skhu/skhucapstone/club/api/dto/Response/ClubResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/club/api/dto/Response/ClubResponse.java
@@ -1,0 +1,25 @@
+package com.skhu.skhucapstone.club.api.dto.Response;
+
+import com.skhu.skhucapstone.club.domain.Club;
+
+import java.time.LocalDateTime;
+
+public record ClubResponse(
+        Long id,
+        String clubName,
+        String description,
+        Boolean isApproved,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ClubResponse from(Club club) {
+        return new ClubResponse(
+                club.getId(),
+                club.getClubName(),
+                club.getDescription(),
+                club.getIsApproved(),
+                club.getCreatedAt(),
+                club.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/club/api/dto/Response/ClubResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/club/api/dto/Response/ClubResponse.java
@@ -7,7 +7,13 @@ import java.time.LocalDateTime;
 public record ClubResponse(
         Long id,
         String clubName,
-        String description,
+        String category,
+        String shortDescription,
+        String detailDescription,
+        String imageUrl,
+        String regularMeetingTime,
+        String activityLocation,
+        String contact,
         Boolean isApproved,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
@@ -16,7 +22,13 @@ public record ClubResponse(
         return new ClubResponse(
                 club.getId(),
                 club.getClubName(),
-                club.getDescription(),
+                club.getCategory(),
+                club.getShortDescription(),
+                club.getDetailDescription(),
+                club.getImageUrl(),
+                club.getRegularMeetingTime(),
+                club.getActivityLocation(),
+                club.getContact(),
                 club.isApproved(),
                 club.getCreatedAt(),
                 club.getUpdatedAt()

--- a/src/main/java/com/skhu/skhucapstone/club/api/dto/Response/ClubResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/club/api/dto/Response/ClubResponse.java
@@ -17,7 +17,7 @@ public record ClubResponse(
                 club.getId(),
                 club.getClubName(),
                 club.getDescription(),
-                club.getIsApproved(),
+                club.isApproved(),
                 club.getCreatedAt(),
                 club.getUpdatedAt()
         );

--- a/src/main/java/com/skhu/skhucapstone/club/application/ClubService.java
+++ b/src/main/java/com/skhu/skhucapstone/club/application/ClubService.java
@@ -1,0 +1,45 @@
+package com.skhu.skhucapstone.club.application;
+
+import com.skhu.skhucapstone.club.api.dto.Request.ClubCreateRequest;
+import com.skhu.skhucapstone.club.api.dto.Response.ClubResponse;
+import com.skhu.skhucapstone.club.domain.Club;
+import com.skhu.skhucapstone.club.domain.repository.ClubRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubService {
+
+    private final ClubRepository clubRepository;
+
+    @Transactional
+    public ClubResponse createClub(ClubCreateRequest request) {
+        Club club = Club.builder()
+                .clubName(request.clubName())
+                .description(request.description())
+                .build();
+
+        Club savedClub = clubRepository.save(club);
+
+        return ClubResponse.from(savedClub);
+    }
+
+    public List<ClubResponse> getClubs() {
+        return clubRepository.findAll()
+                .stream()
+                .map(ClubResponse::from)
+                .toList();
+    }
+
+    public ClubResponse getClub(Long clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동아리입니다."));
+
+        return ClubResponse.from(club);
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/club/application/ClubService.java
+++ b/src/main/java/com/skhu/skhucapstone/club/application/ClubService.java
@@ -30,7 +30,7 @@ public class ClubService {
     }
 
     public List<ClubResponse> getClubs() {
-        return clubRepository.findAll()
+        return clubRepository.findByApprovedTrue()
                 .stream()
                 .map(ClubResponse::from)
                 .toList();
@@ -38,7 +38,7 @@ public class ClubService {
 
     public ClubResponse getClub(Long clubId) {
         Club club = clubRepository.findById(clubId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 동아리입니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID의 동아리를 찾을 수 없습니다. clubId = " + clubId));
 
         return ClubResponse.from(club);
     }

--- a/src/main/java/com/skhu/skhucapstone/club/application/ClubService.java
+++ b/src/main/java/com/skhu/skhucapstone/club/application/ClubService.java
@@ -21,7 +21,13 @@ public class ClubService {
     public ClubResponse createClub(ClubCreateRequest request) {
         Club club = Club.builder()
                 .clubName(request.clubName())
-                .description(request.description())
+                .category(request.category())
+                .shortDescription(request.shortDescription())
+                .detailDescription(request.detailDescription())
+                .imageUrl(request.imageUrl())
+                .regularMeetingTime(request.regularMeetingTime())
+                .activityLocation(request.activityLocation())
+                .contact(request.contact())
                 .build();
 
         Club savedClub = clubRepository.save(club);

--- a/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
+++ b/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
@@ -44,7 +44,7 @@ public class Club {
     private String contact;
 
     @Column(name = "is_approved", nullable = false)
-    private boolean isApproved;
+    private boolean approved;
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
@@ -71,18 +71,18 @@ public class Club {
         this.regularMeetingTime = regularMeetingTime;
         this.activityLocation = activityLocation;
         this.contact = contact;
-        this.isApproved = false;
+        this.approved = false;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
     }
 
     public void approve() {
-        this.isApproved = true;
+        this.approved = true;
         this.updatedAt = LocalDateTime.now();
     }
 
     public void reject() {
-        this.isApproved = false;
+        this.approved = false;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
+++ b/src/main/java/com/skhu/skhucapstone/club/domain/Club.java
@@ -1,11 +1,6 @@
 package com.skhu.skhucapstone.club.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,8 +22,26 @@ public class Club {
     @Column(name = "club_name", nullable = false, length = 100)
     private String clubName;
 
-    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
-    private String description;
+    @Column(name = "category", nullable = false, length = 50)
+    private String category;
+
+    @Column(name = "short_description", nullable = false, length = 255)
+    private String shortDescription;
+
+    @Column(name = "detail_description", nullable = false, columnDefinition = "TEXT")
+    private String detailDescription;
+
+    @Column(name = "image_url", length = 1000)
+    private String imageUrl;
+
+    @Column(name = "regular_meeting_time", nullable = false, length = 100)
+    private String regularMeetingTime;
+
+    @Column(name = "activity_location", nullable = false, length = 255)
+    private String activityLocation;
+
+    @Column(name = "contact", nullable = false, length = 100)
+    private String contact;
 
     @Column(name = "is_approved", nullable = false)
     private boolean isApproved;
@@ -40,9 +53,24 @@ public class Club {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Club(String clubName, String description) {
+    public Club(
+            String clubName,
+            String category,
+            String shortDescription,
+            String detailDescription,
+            String imageUrl,
+            String regularMeetingTime,
+            String activityLocation,
+            String contact
+    ) {
         this.clubName = clubName;
-        this.description = description;
+        this.category = category;
+        this.shortDescription = shortDescription;
+        this.detailDescription = detailDescription;
+        this.imageUrl = imageUrl;
+        this.regularMeetingTime = regularMeetingTime;
+        this.activityLocation = activityLocation;
+        this.contact = contact;
         this.isApproved = false;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
@@ -58,9 +86,24 @@ public class Club {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void updateInfo(String clubName, String description) {
+    public void updateInfo(
+            String clubName,
+            String category,
+            String shortDescription,
+            String detailDescription,
+            String imageUrl,
+            String regularMeetingTime,
+            String activityLocation,
+            String contact
+    ) {
         this.clubName = clubName;
-        this.description = description;
+        this.category = category;
+        this.shortDescription = shortDescription;
+        this.detailDescription = detailDescription;
+        this.imageUrl = imageUrl;
+        this.regularMeetingTime = regularMeetingTime;
+        this.activityLocation = activityLocation;
+        this.contact = contact;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/skhu/skhucapstone/club/domain/repository/ClubRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/club/domain/repository/ClubRepository.java
@@ -1,0 +1,7 @@
+package com.skhu.skhucapstone.club.domain.repository;
+
+import com.skhu.skhucapstone.club.domain.Club;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClubRepository extends JpaRepository<Club, Long> {
+}

--- a/src/main/java/com/skhu/skhucapstone/club/domain/repository/ClubRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/club/domain/repository/ClubRepository.java
@@ -3,5 +3,9 @@ package com.skhu.skhucapstone.club.domain.repository;
 import com.skhu.skhucapstone.club.domain.Club;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ClubRepository extends JpaRepository<Club, Long> {
+
+    List<Club> findByApprovedTrue();
 }

--- a/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
@@ -29,6 +29,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/google/login",
                                 "/swagger-ui/**",
+                                "/api/clubs/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/webjars/**"


### PR DESCRIPTION
동아리 생성 및 조회 기능 구현 (#11)

## 작업 내용
- 동아리 생성 API 구현 (POST /api/clubs)
- 동아리 전체 조회 API 구현 (GET /api/clubs)
- 동아리 상세 조회 API 구현 (GET /api/clubs/{clubId})

##  주요 변경 사항
- ClubRepository, ClubCreateRequest, ClubResponse DTO 추가
- Service / Controller 계층 구현
- 동아리 생성 시 isApproved 기본값 false 적용

## 개선 및 수정 사항 (직접 작업)
- 승인된 동아리만 조회하도록 로직 수정 (findAll → findByApprovedTrue)
- boolean 필드 매핑 문제 해결 (getIsApproved 관련 오류 수정)
- 피그마 신청 양식 기준으로 Club 필드 확장(category, shortDescription, detailDescription 등 추가)
- Controller에서 @Valid 위치 수정 및 요청 검증 적용
- Club 엔티티 JPA 매핑 오류 수정 (@Id, 필드 누락 문제 해결)

## AI 활용 및 개선
- Service / Controller 초기 구조는 AI 초안을 기반으로 작성
- 이후 조회 정책, 엔티티 구조, 유효성 검증, JPA 오류 등을 직접 수정 및 개선

## 테스트
- Postman을 통해 생성/조회 API 정상 동작 확인
<img width="782" height="757" alt="image" src="https://github.com/user-attachments/assets/fef609d2-0209-4f9c-a5dc-e177a3bd82af" />
-> "isApproved": false 로 잘 나옴
<img width="579" height="572" alt="image" src="https://github.com/user-attachments/assets/fe9d31f2-e0ba-4805-865e-d1f275c15331" />
->findByApprovedTrue() 현재 이렇게 승인된 동아리만 전체조회가 가능하기 때문에 현재 개발 상황에선 [] 뜨는게 정상
