### PR TITLE
[Feat]  마이페이지 및 커피챗 프로필 API 구현

### DIFF
--- a/src/main/java/com/skhu/skhucapstone/clubmember/domain/repository/ClubMemberRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/clubmember/domain/repository/ClubMemberRepository.java
@@ -1,0 +1,12 @@
+package com.skhu.skhucapstone.clubmember.domain.repository;
+
+import com.skhu.skhucapstone.clubmember.domain.ClubJoinStatus;
+import com.skhu.skhucapstone.clubmember.domain.ClubMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
+
+    List<ClubMember> findByUserUserIdAndClubJoinStatus(Long userId, ClubJoinStatus clubJoinStatus);
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/controller/CoffeeChatController.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/controller/CoffeeChatController.java
@@ -1,0 +1,39 @@
+package com.skhu.skhucapstone.coffeechat.controller;
+
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileListRes;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatUserProfileRes;
+import com.skhu.skhucapstone.coffeechat.service.CoffeeChatService;
+import com.skhu.skhucapstone.common.exception.SuccessCode;
+import com.skhu.skhucapstone.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/coffeechat")
+@RequiredArgsConstructor
+@Tag(name = "CoffeeChat", description = "커피챗 프로필 API")
+public class CoffeeChatController {
+
+    private final CoffeeChatService coffeeChatService;
+
+    @GetMapping("/profiles/{userId}")
+    @Operation(summary = "커피챗 프로필 단건 조회", description = "특정 유저의 커피챗 프로필을 조회합니다. 비공개 프로필은 조회할 수 없습니다.")
+    public ResponseEntity<ApiResponse<CoffeeChatUserProfileRes>> getUserProfile(
+            @PathVariable Long userId) {
+        CoffeeChatUserProfileRes res = coffeeChatService.getUserProfile(userId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.COFFEECHAT_PROFILE_GET_SUCCESS, res));
+    }
+
+    @GetMapping("/profiles")
+    @Operation(summary = "커피챗 프로필 목록 조회", description = "공개된 커피챗 프로필 목록을 조회합니다. 키워드로 검색할 수 있습니다.")
+    public ResponseEntity<ApiResponse<CoffeeChatProfileListRes>> getProfiles(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        CoffeeChatProfileListRes res = coffeeChatService.getProfiles(keyword, page, size);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.COFFEECHAT_PROFILE_LIST_GET_SUCCESS, res));
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/dto/req/CoffeeChatProfileSaveReq.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/dto/req/CoffeeChatProfileSaveReq.java
@@ -1,0 +1,22 @@
+package com.skhu.skhucapstone.coffeechat.dto.req;
+
+import com.skhu.skhucapstone.coffeechat.entity.MeetingType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CoffeeChatProfileSaveReq {
+
+    private String studentId;
+
+    private String headline;
+
+    private String interestTopics;
+
+    private MeetingType meetingType;
+
+    private String contactLink;
+
+    private String introduction;
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/dto/req/CoffeeChatProfileVisibilityReq.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/dto/req/CoffeeChatProfileVisibilityReq.java
@@ -1,0 +1,13 @@
+package com.skhu.skhucapstone.coffeechat.dto.req;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CoffeeChatProfileVisibilityReq {
+
+    @NotNull(message = "공개 여부를 선택해주세요.")
+    private Boolean isPublic;
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileListItemRes.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileListItemRes.java
@@ -1,0 +1,35 @@
+package com.skhu.skhucapstone.coffeechat.dto.res;
+
+import com.skhu.skhucapstone.coffeechat.entity.CoffeeChatProfile;
+import com.skhu.skhucapstone.coffeechat.entity.MeetingType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoffeeChatProfileListItemRes {
+
+    private Long coffeeChatProfileId;
+    private Long userId;
+    private String name;
+    private String headline;
+    private String interestTopics;
+    private List<String> clubs;
+    private MeetingType meetingType;
+    private Boolean isPublic;
+
+    public static CoffeeChatProfileListItemRes of(CoffeeChatProfile profile, List<String> clubs) {
+        return CoffeeChatProfileListItemRes.builder()
+                .coffeeChatProfileId(profile.getId())
+                .userId(profile.getUser().getUserId())
+                .name(profile.getUser().getName())
+                .headline(profile.getHeadline())
+                .interestTopics(profile.getInterestTopics())
+                .clubs(clubs)
+                .meetingType(profile.getMeetingType())
+                .isPublic(profile.getIsPublic())
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileListRes.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileListRes.java
@@ -1,0 +1,28 @@
+package com.skhu.skhucapstone.coffeechat.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoffeeChatProfileListRes {
+
+    private List<CoffeeChatProfileListItemRes> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+
+    public static CoffeeChatProfileListRes from(Page<CoffeeChatProfileListItemRes> pageData) {
+        return CoffeeChatProfileListRes.builder()
+                .content(pageData.getContent())
+                .page(pageData.getNumber())
+                .size(pageData.getSize())
+                .totalElements(pageData.getTotalElements())
+                .totalPages(pageData.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileRes.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileRes.java
@@ -1,0 +1,33 @@
+package com.skhu.skhucapstone.coffeechat.dto.res;
+
+import com.skhu.skhucapstone.coffeechat.entity.CoffeeChatProfile;
+import com.skhu.skhucapstone.coffeechat.entity.MeetingType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CoffeeChatProfileRes {
+
+    private Long coffeeChatProfileId;
+    private String studentId;
+    private String headline;
+    private String interestTopics;
+    private MeetingType meetingType;
+    private String contactLink;
+    private String introduction;
+    private Boolean isPublic;
+
+    public static CoffeeChatProfileRes from(CoffeeChatProfile profile) {
+        return CoffeeChatProfileRes.builder()
+                .coffeeChatProfileId(profile.getId())
+                .studentId(profile.getStudentId())
+                .headline(profile.getHeadline())
+                .interestTopics(profile.getInterestTopics())
+                .meetingType(profile.getMeetingType())
+                .contactLink(profile.getContactLink())
+                .introduction(profile.getIntroduction())
+                .isPublic(profile.getIsPublic())
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileVisibilityRes.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatProfileVisibilityRes.java
@@ -1,0 +1,20 @@
+package com.skhu.skhucapstone.coffeechat.dto.res;
+
+import com.skhu.skhucapstone.coffeechat.entity.CoffeeChatProfile;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CoffeeChatProfileVisibilityRes {
+
+    private Long coffeeChatProfileId;
+    private Boolean isPublic;
+
+    public static CoffeeChatProfileVisibilityRes from(CoffeeChatProfile profile) {
+        return CoffeeChatProfileVisibilityRes.builder()
+                .coffeeChatProfileId(profile.getId())
+                .isPublic(profile.getIsPublic())
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatUserProfileRes.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/dto/res/CoffeeChatUserProfileRes.java
@@ -1,0 +1,26 @@
+package com.skhu.skhucapstone.coffeechat.dto.res;
+
+import com.skhu.skhucapstone.coffeechat.entity.CoffeeChatProfile;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoffeeChatUserProfileRes {
+
+    private Long userId;
+    private String name;
+    private List<String> clubs;
+    private CoffeeChatProfileRes coffeeChatProfile;
+
+    public static CoffeeChatUserProfileRes of(CoffeeChatProfile profile, List<String> clubs) {
+        return CoffeeChatUserProfileRes.builder()
+                .userId(profile.getUser().getUserId())
+                .name(profile.getUser().getName())
+                .clubs(clubs)
+                .coffeeChatProfile(CoffeeChatProfileRes.from(profile))
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/entity/CoffeeChatProfile.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/entity/CoffeeChatProfile.java
@@ -1,0 +1,64 @@
+package com.skhu.skhucapstone.coffeechat.entity;
+
+import com.skhu.skhucapstone.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicInsert
+@Table(name = "coffeechat_profile")
+public class CoffeeChatProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(nullable = false)
+    private String studentId;
+
+    @Column(nullable = false)
+    private String headline;
+
+    @Column(nullable = false)
+    private String interestTopics;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MeetingType meetingType;
+
+    @Column(nullable = false)
+    private String contactLink;
+
+    @Column(columnDefinition = "TEXT")
+    private String introduction;
+
+    @Builder.Default
+    @ColumnDefault("true")
+    @Column(nullable = false)
+    private Boolean isPublic = true;
+
+    public void update(String studentId, String headline, String interestTopics, MeetingType meetingType, String contactLink, String introduction, Boolean isPublic) {
+        this.studentId = studentId;
+        this.headline = headline;
+        this.interestTopics = interestTopics;
+        this.meetingType = meetingType;
+        this.contactLink = contactLink;
+        this.introduction = introduction;
+        this.isPublic = isPublic;
+    }
+
+    // 커피챗 공개 유무
+    public void updateVisibility(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/entity/MeetingType.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/entity/MeetingType.java
@@ -1,0 +1,5 @@
+package com.skhu.skhucapstone.coffeechat.entity;
+
+public enum MeetingType {
+    ONLINE, OFFLINE, ONLINE_OFFLINE
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/repository/CoffeeChatProfileRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/repository/CoffeeChatProfileRepository.java
@@ -1,0 +1,21 @@
+package com.skhu.skhucapstone.coffeechat.repository;
+
+import com.skhu.skhucapstone.coffeechat.entity.CoffeeChatProfile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CoffeeChatProfileRepository extends JpaRepository<CoffeeChatProfile, Long> {
+
+    Optional<CoffeeChatProfile> findByUserUserId(Long userId);
+
+    @Query("SELECT c FROM CoffeeChatProfile c WHERE c.isPublic = true " +
+            "AND (:keyword IS NULL OR c.headline LIKE %:keyword% " +
+            "OR c.interestTopics LIKE %:keyword% " +
+            "OR c.user.name LIKE %:keyword%)")
+    Page<CoffeeChatProfile> searchProfiles(@Param("keyword") String keyword, Pageable pageable);
+}

--- a/src/main/java/com/skhu/skhucapstone/coffeechat/service/CoffeeChatService.java
+++ b/src/main/java/com/skhu/skhucapstone/coffeechat/service/CoffeeChatService.java
@@ -1,0 +1,127 @@
+package com.skhu.skhucapstone.coffeechat.service;
+
+import com.skhu.skhucapstone.clubmember.domain.ClubJoinStatus;
+import com.skhu.skhucapstone.clubmember.domain.ClubMember;
+import com.skhu.skhucapstone.clubmember.domain.repository.ClubMemberRepository;
+import com.skhu.skhucapstone.coffeechat.dto.req.CoffeeChatProfileSaveReq;
+import com.skhu.skhucapstone.coffeechat.dto.req.CoffeeChatProfileVisibilityReq;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileListItemRes;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileListRes;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileRes;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileVisibilityRes;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatUserProfileRes;
+import com.skhu.skhucapstone.coffeechat.entity.CoffeeChatProfile;
+import com.skhu.skhucapstone.coffeechat.repository.CoffeeChatProfileRepository;
+import com.skhu.skhucapstone.common.exception.CustomException;
+import com.skhu.skhucapstone.common.exception.ErrorCode;
+import com.skhu.skhucapstone.user.entity.User;
+import com.skhu.skhucapstone.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CoffeeChatService {
+
+    private final CoffeeChatProfileRepository coffeeChatProfileRepository;
+    private final UserRepository userRepository;
+    private final ClubMemberRepository clubMemberRepository;
+
+    // 커피챗 프로필 저장 (없으면 생성, 있으면 수정)
+    @Transactional
+    public CoffeeChatProfileRes saveProfile(Long userId, CoffeeChatProfileSaveReq req) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        CoffeeChatProfile profile = coffeeChatProfileRepository.findByUserUserId(userId)
+                .map(existing -> {
+                    // null인 필드는 기존 값 유지
+                    existing.update(
+                            req.getStudentId() != null ? req.getStudentId() : existing.getStudentId(),
+                            req.getHeadline() != null ? req.getHeadline() : existing.getHeadline(),
+                            req.getInterestTopics() != null ? req.getInterestTopics() : existing.getInterestTopics(),
+                            req.getMeetingType() != null ? req.getMeetingType() : existing.getMeetingType(),
+                            req.getContactLink() != null ? req.getContactLink() : existing.getContactLink(),
+                            req.getIntroduction() != null ? req.getIntroduction() : existing.getIntroduction(),
+                            existing.getIsPublic()
+                    );
+                    return existing;
+                })
+                // 프로필 없으면 새로 생성
+                .orElseGet(() -> coffeeChatProfileRepository.save(
+                        CoffeeChatProfile.builder()
+                                .user(user)
+                                .studentId(req.getStudentId())
+                                .headline(req.getHeadline())
+                                .interestTopics(req.getInterestTopics())
+                                .meetingType(req.getMeetingType())
+                                .contactLink(req.getContactLink())
+                                .introduction(req.getIntroduction())
+                                .build()
+                ));
+
+        return CoffeeChatProfileRes.from(profile);
+    }
+
+    // 커피챗 프로필 공개여부 변경
+    @Transactional
+    public CoffeeChatProfileVisibilityRes updateVisibility(Long userId, CoffeeChatProfileVisibilityReq req) {
+        CoffeeChatProfile profile = coffeeChatProfileRepository.findByUserUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COFFEECHAT_PROFILE_NOT_FOUND));
+
+        profile.updateVisibility(req.getIsPublic());
+
+        return CoffeeChatProfileVisibilityRes.from(profile);
+    }
+
+    // 특정 유저 커피챗 프로필 조회 (비공개면 조회 불가)
+    @Transactional(readOnly = true)
+    public CoffeeChatUserProfileRes getUserProfile(Long targetUserId) {
+        CoffeeChatProfile profile = coffeeChatProfileRepository.findByUserUserId(targetUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COFFEECHAT_PROFILE_NOT_FOUND));
+
+        // 비공개 프로필 접근 차단
+        if (!profile.getIsPublic()) {
+            throw new CustomException(ErrorCode.COFFEECHAT_PROFILE_PRIVATE);
+        }
+
+        List<String> clubs = getClubs(targetUserId);
+
+        return CoffeeChatUserProfileRes.of(profile, clubs);
+    }
+
+    // 커피챗 프로필 목록 조회 (키워드 검색 + 페이징)
+    @Transactional(readOnly = true)
+    public CoffeeChatProfileListRes getProfiles(String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        // 빈 문자열이면 전체 조회
+        String searchKeyword = (keyword == null || keyword.isBlank()) ? null : keyword;
+
+        return CoffeeChatProfileListRes.from(
+                coffeeChatProfileRepository.searchProfiles(searchKeyword, pageable)
+                        .map(profile -> CoffeeChatProfileListItemRes.of(
+                                profile,
+                                getClubs(profile.getUser().getUserId())
+                        ))
+        );
+    }
+
+    // 유저의 동아리 목록 조회 (동아리명 / 역할)
+    private List<String> getClubs(Long userId) {
+        List<ClubMember> clubMembers = clubMemberRepository
+                .findByUserUserIdAndClubJoinStatus(userId, ClubJoinStatus.JOINED);
+
+        // 가입한 동아리 없으면 null
+        if (clubMembers.isEmpty()) return null;
+
+        return clubMembers.stream()
+                .map(cm -> cm.getClub().getClubName() + " / " + cm.getRole().name())
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
@@ -26,7 +26,15 @@ public enum ErrorCode {
 
     // 공통
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그인이 필요합니다."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "올바르지 않은 요청입니다.");
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "올바르지 않은 요청입니다."),
+
+    // 커피챗
+    COFFEECHAT_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "COFFEECHAT_PROFILE_NOT_FOUND", "커피챗 프로필을 찾을 수 없습니다."),
+    INVALID_COFFEECHAT_PROFILE_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_COFFEECHAT_PROFILE_REQUEST", "커피챗 프로필 요청 형식이 올바르지 않습니다."),
+    COFFEECHAT_PROFILE_PRIVATE(HttpStatus.FORBIDDEN, "COFFEECHAT_PROFILE_PRIVATE", "비공개 커피챗 프로필입니다."),
+
+    // 유저
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
@@ -13,7 +13,16 @@ public enum SuccessCode {
     // 인증번호
     EMAIL_SEND_SUCCESS(HttpStatus.OK, "EMAIL_SEND_SUCCESS", "인증번호가 발송되었습니다."),
     EMAIL_VERIFY_SUCCESS(HttpStatus.OK, "EMAIL_VERIFY_SUCCESS", "학교 이메일 인증이 완료되었습니다."),
-    EMAIL_RESEND_SUCCESS(HttpStatus.OK, "EMAIL_RESEND_SUCCESS", "인증번호가 재발송되었습니다.");
+    EMAIL_RESEND_SUCCESS(HttpStatus.OK, "EMAIL_RESEND_SUCCESS", "인증번호가 재발송되었습니다."),
+
+    // 커피챗
+    COFFEECHAT_PROFILE_SAVE_SUCCESS(HttpStatus.OK, "COFFEECHAT_PROFILE_SAVE_SUCCESS", "커피챗 프로필이 저장되었습니다."),
+    COFFEECHAT_PROFILE_VISIBILITY_UPDATE_SUCCESS(HttpStatus.OK, "COFFEECHAT_PROFILE_VISIBILITY_UPDATE_SUCCESS", "커피챗 프로필 공개 여부가 변경되었습니다."),
+    COFFEECHAT_PROFILE_GET_SUCCESS(HttpStatus.OK, "COFFEECHAT_PROFILE_GET_SUCCESS", "커피챗 프로필 조회가 완료되었습니다."),
+    COFFEECHAT_PROFILE_LIST_GET_SUCCESS(HttpStatus.OK, "COFFEECHAT_PROFILE_LIST_GET_SUCCESS", "커피챗 프로필 목록 조회가 완료되었습니다."),
+
+    // 마이페이지
+    MYPAGE_GET_SUCCESS(HttpStatus.OK, "MYPAGE_GET_SUCCESS", "마이페이지 조회가 완료되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/skhu/skhucapstone/common/security/SwaggerConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/security/SwaggerConfig.java
@@ -5,8 +5,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class SwaggerConfig {
@@ -28,8 +31,13 @@ public class SwaggerConfig {
                         .title("SKHU Capstone API")
                         .description("성공회대학교 캡스톤 디자인 API 명세서")
                         .version("1.0.0"))
+                .servers(List.of(
+                        new Server().url("https://skhucapstone.duckdns.org").description("Production Server"),
+                        new Server().url("http://localhost:8080").description("Local Server")
+                ))
                 .addSecurityItem(securityRequirement)
                 .components(new Components()
                         .addSecuritySchemes("bearerAuth", securityScheme));
     }
 }
+

--- a/src/main/java/com/skhu/skhucapstone/mypage/controller/MypageController.java
+++ b/src/main/java/com/skhu/skhucapstone/mypage/controller/MypageController.java
@@ -1,0 +1,53 @@
+package com.skhu.skhucapstone.mypage.controller;
+
+import com.skhu.skhucapstone.coffeechat.dto.req.CoffeeChatProfileSaveReq;
+import com.skhu.skhucapstone.coffeechat.dto.req.CoffeeChatProfileVisibilityReq;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileRes;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileVisibilityRes;
+import com.skhu.skhucapstone.coffeechat.service.CoffeeChatService;
+import com.skhu.skhucapstone.common.exception.SuccessCode;
+import com.skhu.skhucapstone.common.response.ApiResponse;
+import com.skhu.skhucapstone.mypage.dto.MypageRes;
+import com.skhu.skhucapstone.mypage.service.MypageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+@Tag(name = "Mypage", description = "마이페이지 API")
+public class MypageController {
+
+    private final MypageService mypageService;
+    private final CoffeeChatService coffeeChatService;
+
+    @GetMapping
+    @Operation(summary = "마이페이지 조회", description = "내 프로필과 커피챗 프로필을 조회합니다.")
+    public ResponseEntity<ApiResponse<MypageRes>> getMypage(
+            @AuthenticationPrincipal Long userId) {
+        MypageRes res = mypageService.getMypage(userId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MYPAGE_GET_SUCCESS, res));
+    }
+
+    @PutMapping("/coffeechat-profile")
+    @Operation(summary = "커피챗 프로필 저장", description = "커피챗 프로필을 저장합니다. 없으면 생성, 있으면 수정합니다.")
+    public ResponseEntity<ApiResponse<CoffeeChatProfileRes>> saveCoffeeChatProfile(
+            @RequestBody CoffeeChatProfileSaveReq req,
+            @AuthenticationPrincipal Long userId) {
+        CoffeeChatProfileRes res = coffeeChatService.saveProfile(userId, req);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.COFFEECHAT_PROFILE_SAVE_SUCCESS, res));
+    }
+
+    @PatchMapping("/coffeechat-profile/visibility")
+    @Operation(summary = "커피챗 프로필 공개여부 변경", description = "커피챗 프로필 공개여부를 변경합니다.")
+    public ResponseEntity<ApiResponse<CoffeeChatProfileVisibilityRes>> updateVisibility(
+            @RequestBody CoffeeChatProfileVisibilityReq req,
+            @AuthenticationPrincipal Long userId) {
+        CoffeeChatProfileVisibilityRes res = coffeeChatService.updateVisibility(userId, req);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.COFFEECHAT_PROFILE_VISIBILITY_UPDATE_SUCCESS, res));
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/mypage/dto/MypageRes.java
+++ b/src/main/java/com/skhu/skhucapstone/mypage/dto/MypageRes.java
@@ -1,0 +1,29 @@
+package com.skhu.skhucapstone.mypage.dto;
+
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileRes;
+import com.skhu.skhucapstone.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MypageRes {
+
+    private String name;
+    private String email;
+    private String schoolEmail;
+    private List<String> clubs;
+    private CoffeeChatProfileRes coffeeChatProfile;
+
+    public static MypageRes of(User user, List<String> clubs, CoffeeChatProfileRes coffeeChatProfile) {
+        return MypageRes.builder()
+                .name(user.getName())
+                .email(user.getEmail())
+                .schoolEmail(user.getSchoolEmail())
+                .clubs(clubs)
+                .coffeeChatProfile(coffeeChatProfile)
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/mypage/service/MypageService.java
+++ b/src/main/java/com/skhu/skhucapstone/mypage/service/MypageService.java
@@ -1,0 +1,56 @@
+package com.skhu.skhucapstone.mypage.service;
+
+import com.skhu.skhucapstone.clubmember.domain.ClubJoinStatus;
+import com.skhu.skhucapstone.clubmember.domain.ClubMember;
+import com.skhu.skhucapstone.clubmember.domain.repository.ClubMemberRepository;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileRes;
+import com.skhu.skhucapstone.coffeechat.repository.CoffeeChatProfileRepository;
+import com.skhu.skhucapstone.common.exception.CustomException;
+import com.skhu.skhucapstone.common.exception.ErrorCode;
+import com.skhu.skhucapstone.mypage.dto.MypageRes;
+import com.skhu.skhucapstone.user.entity.User;
+import com.skhu.skhucapstone.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MypageService {
+
+    private final UserRepository userRepository;
+    private final CoffeeChatProfileRepository coffeeChatProfileRepository;
+    private final ClubMemberRepository clubMemberRepository;
+
+    // 마이페이지 조회 (유저 정보 + 동아리 + 커피챗 프로필)
+    @Transactional(readOnly = true)
+    public MypageRes getMypage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<String> clubs = getClubs(userId);
+
+        // 커피챗 프로필 없으면 null
+        CoffeeChatProfileRes coffeeChatProfileRes = coffeeChatProfileRepository.findByUserUserId(userId)
+                .map(CoffeeChatProfileRes::from)
+                .orElse(null);
+
+        return MypageRes.of(user, clubs, coffeeChatProfileRes);
+    }
+
+    // 유저의 동아리 목록 조회 (동아리명 / 역할)
+    private List<String> getClubs(Long userId) {
+        List<ClubMember> clubMembers = clubMemberRepository
+                .findByUserUserIdAndClubJoinStatus(userId, ClubJoinStatus.JOINED);
+
+        // 가입한 동아리 없으면 null
+        if (clubMembers.isEmpty()) return null;
+
+        return clubMembers.stream()
+                .map(cm -> cm.getClub().getClubName() + " / " + cm.getRole().name())
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #19

## 작업 목적
사용자가 본인의 프로필을 관리하고, 커피챗을 통해 다른 유저와 연결될 수 있도록 마이페이지 조회 및 커피챗 프로필 관련 API 구현

## 작업 배경
기존에는 구글 로그인 후 유저 기본 정보만 존재했고, 유저가 본인 정보를 확인하거나 커피챗 프로필을 등록/관리할 수 있는 기능이 없었음.
프론트엔드 마이페이지 화면 구현을 위해 유저 정보 + 커피챗 프로필을 함께 반환하는 API와, 다른 유저의 커피챗 프로필을 탐색할 수 있는 API가 필요하여 작업 시작

## 작업 내용

### 신규 엔티티
- `CoffeeChatProfile`: 커피챗 프로필 정보 (학번, 한줄소개, 관심분야, 미팅방식, 연락링크, 자기소개, 공개여부)
- `MeetingType`: ONLINE / OFFLINE / ONLINE_OFFLINE enum

### 구현 API
| Method | URL | 설명 |
|--------|-----|------|
| GET | /api/mypage | 마이페이지 조회 (유저 정보 + 동아리 + 커피챗 프로필) |
| PUT | /api/mypage/coffeechat-profile | 커피챗 프로필 저장 (upsert) |
| PATCH | /api/mypage/coffeechat-profile/visibility | 커피챗 프로필 공개여부 변경 |
| GET | /api/coffeechat/profiles/{userId} | 특정 유저 커피챗 프로필 단건 조회 |
| GET | /api/coffeechat/profiles | 커피챗 프로필 목록 조회 (키워드 검색 + 페이징) |

### 주요 설계 결정

**1. CoffeeChatProfile 별도 엔티티 분리**
커피챗 미사용 유저를 고려해 User 테이블에 필드 추가 대신 별도 엔티티로 분리.
커피챗 프로필이 없는 유저는 row 자체가 존재하지 않음

**2. 저장/공개여부 분리**
PUT 저장 API와 PATCH 공개여부 API를 분리하여 토글 즉시 반영 UX 지원.
isPublic은 SaveReq에서 제외하고 visibility API에서만 관리

**3. upsert + null 필드 기존 값 유지**
PUT 저장은 없으면 생성, 있으면 수정하는 upsert 방식.
수정 시 null 필드는 기존 값을 유지하여 부분 수정 가능하도록 구현

**4. 동아리 복수 소속 처리**
한 유저가 여러 동아리에 소속될 수 있어 `List<String>` 형태로 반환.
"동아리명 / 역할" 형식으로 포맷, 동아리 없으면 null 반환

**5. DTO 구조 설계**
- `CoffeeChatProfileRes`를 공통 DTO로 사용하여 MypageRes, CoffeeChatUserProfileRes에 임베딩
- `CoffeeChatProfileListRes` 래퍼 DTO 생성으로 Spring Page 불필요한 필드 제거
  (empty, first, last, pageable, sort 등 제외)

### AI 활용
1. Repository @Query 작성
키워드 검색 시 여러 필드(한줄소개, 관심분야, 유저명)를 OR 조건으로 검색하고, keyword가 null일 때 전체 조회로 분기하는 JPQL 작성에 AI 활용.
메서드 네이밍으로는 표현 불가능한 복합 조건이라 @Query 방식 채택

2. Service 구조 설계
upsert 로직에서 Optional.map (기존 프로필 수정) + orElseGet (신규 생성) 패턴 구성, null 필드 기존 값 유지를 위한 삼항 연산자 처리, 동아리 목록 포맷팅 등 반복적인 로직 구조 작성에 AI 활용.
에러코드는 기존 프로젝트 컨벤션에 맞게 직접 수정
(INVALID_COFFEECHAT_PROFILE_REQUEST → COFFEECHAT_PROFILE_PRIVATE 등)

3. DTO 구조 설계 검토
초기에 CoffeeChatProfileSaveRes와 CoffeeChatProfileRes를 별도로 설계했으나 AI 검토 과정에서 userId 중복 불필요 확인 후 하나로 통합.
UserInfoRes nested 구조 → flat 구조 변경, Page<T> 직접 반환 시 불필요한 필드 노출 문제를 CoffeeChatProfileListRes 래퍼로 해결하는 방향도 AI 검토를 통해 도출.
최종 DTO 코드는 AI가 작성한 초안을 기반으로 직접 검토 후 확정

4. Controller 작성
@RestController, @RequestMapping, @Operation 등 반복적인 보일러플레이트 코드 작성에 AI 활용.
API 경로, 요청/응답 타입, SuccessCode는 직접 검토하여 확정

## 테스트 결과

**PUT /api/mypage/coffeechat-profile**
- 최초 저장 시 프로필 생성 확인
- 재저장 시 기존 프로필 수정 확인
- null 필드 전송 시 기존 값 유지 확인

**PATCH /api/mypage/coffeechat-profile/visibility**
- isPublic true/false 변경 확인
- 프로필 없는 유저 요청 시 COFFEECHAT_PROFILE_NOT_FOUND(404) 반환 확인

**GET /api/coffeechat/profiles/{userId}**
- 공개 프로필 정상 조회 확인
- 비공개 프로필 요청 시 COFFEECHAT_PROFILE_PRIVATE(403) 반환 확인

**GET /api/coffeechat/profiles**
- keyword 없이 전체 공개 목록 조회 확인
- keyword 검색 시 한줄소개/관심분야/이름 기준 필터링 확인
- 페이징 정상 동작 확인 (content, page, size, totalElements, totalPages)

**GET /api/mypage**
- 유저 정보 + 커피챗 프로필 함께 반환 확인
- 커피챗 프로필 미등록 유저 조회 시 coffeeChatProfile null 반환 확인