### PR TITLE
[FEAT] 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 
     // 스웨거
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+    // 웹소켓
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/skhu/skhucapstone/chat/controller/ChatController.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/controller/ChatController.java
@@ -46,16 +46,16 @@ public class ChatController {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.CHAT_ROOM_LIST_FETCH_SUCCESS, res));
     }
 
-    // 메시지 전송
-    @PostMapping("/rooms/{chatRoomId}/messages")
-    @Operation(summary = "메시지 전송", description = "채팅방에 메시지를 전송합니다.")
-    public ResponseEntity<ApiResponse<ChatMessageRes>> sendMessage(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable Long chatRoomId,
-            @Valid @RequestBody ChatMessageSendReq req) {
-        ChatMessageRes res = chatService.sendMessage(userId, chatRoomId, req);
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.CHAT_MESSAGE_SEND_SUCCESS, res));
-    }
+    // 메시지 전송 - WebSocket으로 대체됨 (/app/chat/{chatRoomId}/send)
+//    @PostMapping("/rooms/{chatRoomId}/messages")
+//    @Operation(summary = "메시지 전송", description = "채팅방에 메시지를 전송합니다.")
+//    public ResponseEntity<ApiResponse<ChatMessageRes>> sendMessage(
+//            @AuthenticationPrincipal Long userId,
+//            @PathVariable Long chatRoomId,
+//            @Valid @RequestBody ChatMessageSendReq req) {
+//        ChatMessageRes res = chatService.sendMessage(userId, chatRoomId, req);
+//        return ResponseEntity.ok(ApiResponse.success(SuccessCode.CHAT_MESSAGE_SEND_SUCCESS, res));
+//    }
 
     // 채팅방 메시지 목록 조회 (페이징)
     @GetMapping("/rooms/{chatRoomId}/messages")

--- a/src/main/java/com/skhu/skhucapstone/chat/controller/ChatController.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/controller/ChatController.java
@@ -1,0 +1,82 @@
+package com.skhu.skhucapstone.chat.controller;
+
+import com.skhu.skhucapstone.chat.dto.req.ChatMessageReadReq;
+import com.skhu.skhucapstone.chat.dto.req.ChatMessageSendReq;
+import com.skhu.skhucapstone.chat.dto.req.ChatRoomCreateReq;
+import com.skhu.skhucapstone.chat.dto.res.*;
+import com.skhu.skhucapstone.chat.service.ChatService;
+import com.skhu.skhucapstone.common.exception.SuccessCode;
+import com.skhu.skhucapstone.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+@Tag(name = "Chat", description = "채팅 API")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    // 채팅방 isNew=true면 생성, false면 기존 채팅방 반환
+    @PostMapping("/rooms")
+    @Operation(summary = "채팅방 생성 or 반환", description = "상대방과의 채팅방이 없으면 생성하고, 있으면 기존 채팅방을 반환합니다.")
+    public ResponseEntity<ApiResponse<ChatRoomRes>> createOrGetChatRoom(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ChatRoomCreateReq req) {
+        ChatRoomRes res = chatService.createOrGetChatRoom(userId, req);
+        // isNew 여부에 따라 성공 코드 나눔
+        SuccessCode code = res.getIsNew()
+                ? SuccessCode.CHAT_ROOM_CREATE_SUCCESS
+                : SuccessCode.CHAT_ROOM_ALREADY_EXISTS;
+        return ResponseEntity.ok(ApiResponse.success(code, res));
+    }
+
+    // 내 채팅방 목록 조회
+    @GetMapping("/rooms")
+    @Operation(summary = "내 채팅방 목록 조회", description = "내가 참여 중인 채팅방 목록을 최신 메시지 순으로 조회합니다.")
+    public ResponseEntity<ApiResponse<ChatRoomListRes>> getChatRooms(
+            @AuthenticationPrincipal Long userId) {
+        ChatRoomListRes res = chatService.getChatRooms(userId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.CHAT_ROOM_LIST_FETCH_SUCCESS, res));
+    }
+
+    // 메시지 전송
+    @PostMapping("/rooms/{chatRoomId}/messages")
+    @Operation(summary = "메시지 전송", description = "채팅방에 메시지를 전송합니다.")
+    public ResponseEntity<ApiResponse<ChatMessageRes>> sendMessage(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long chatRoomId,
+            @Valid @RequestBody ChatMessageSendReq req) {
+        ChatMessageRes res = chatService.sendMessage(userId, chatRoomId, req);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.CHAT_MESSAGE_SEND_SUCCESS, res));
+    }
+
+    // 채팅방 메시지 목록 조회 (페이징)
+    @GetMapping("/rooms/{chatRoomId}/messages")
+    @Operation(summary = "채팅방 메시지 목록 조회(채팅방 속 메시지들)", description = "채팅방의 메시지 목록을 페이징(20개)으로 조회합니다.")
+    public ResponseEntity<ApiResponse<ChatMessageListRes>> getMessages(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long chatRoomId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        ChatMessageListRes res = chatService.getMessages(userId, chatRoomId, page, size);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.CHAT_MESSAGE_LIST_FETCH_SUCCESS, res));
+    }
+
+    // 메시지 읽음 처리
+    @PatchMapping("/rooms/{chatRoomId}/read")
+    @Operation(summary = "메시지 읽음 처리", description = "채팅방의 특정 메시지들을 읽음 처리합니다.")
+    public ResponseEntity<ApiResponse<ChatMessageReadRes>> readMessages(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long chatRoomId,
+            @RequestBody ChatMessageReadReq req) {
+        ChatMessageReadRes res = chatService.readMessages(userId, chatRoomId, req);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.CHAT_MESSAGE_READ_SUCCESS, res));
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/controller/ChatWebSocketController.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/controller/ChatWebSocketController.java
@@ -1,0 +1,33 @@
+package com.skhu.skhucapstone.chat.controller;
+
+import com.skhu.skhucapstone.chat.dto.req.ChatMessageSendReq;
+import com.skhu.skhucapstone.chat.dto.res.ChatMessageRes;
+import com.skhu.skhucapstone.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatWebSocketController {
+
+    private final ChatService chatService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // 클라이언트가 /app/chat/{chatRoomId}/send 로 메시지를 보내면
+    // 채팅방 구독자 전체에게 /topic/chat/{chatRoomId} 로 브로드캐스트
+    @MessageMapping("/chat/{chatRoomId}/send")
+    public void sendMessage(
+            @DestinationVariable Long chatRoomId,
+            @Payload ChatMessageSendReq req,
+            Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        ChatMessageRes res = chatService.sendMessage(userId, chatRoomId, req);
+        messagingTemplate.convertAndSend("/topic/chat/" + chatRoomId, res);
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/req/ChatMessageReadReq.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/req/ChatMessageReadReq.java
@@ -1,0 +1,12 @@
+package com.skhu.skhucapstone.chat.dto.req;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ChatMessageReadReq {
+
+    // 읽음 처리할 메시지 ID 목록
+    private List<Long> messageIds;
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/req/ChatMessageSendReq.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/req/ChatMessageSendReq.java
@@ -1,0 +1,12 @@
+package com.skhu.skhucapstone.chat.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class ChatMessageSendReq {
+
+    // 메시지 내용 (빈 값 불가)
+    @NotBlank(message = "메시지 내용을 입력해주세요.")
+    private String content;
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/req/ChatRoomCreateReq.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/req/ChatRoomCreateReq.java
@@ -1,0 +1,10 @@
+package com.skhu.skhucapstone.chat.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class ChatRoomCreateReq {
+
+    // 채팅 상대방 userId
+    private Long targetUserId;
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatMessageListRes.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatMessageListRes.java
@@ -1,0 +1,28 @@
+package com.skhu.skhucapstone.chat.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatMessageListRes {
+
+    private List<ChatMessageRes> content;
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+
+    public static ChatMessageListRes from(Page<ChatMessageRes> pageData) {
+        return ChatMessageListRes.builder()
+                .content(pageData.getContent())
+                .page(pageData.getNumber())
+                .size(pageData.getSize())
+                .totalElements(pageData.getTotalElements())
+                .totalPages(pageData.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatMessageReadRes.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatMessageReadRes.java
@@ -1,0 +1,13 @@
+package com.skhu.skhucapstone.chat.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatMessageReadRes {
+
+    private Long chatRoomId;
+    // 실제로 읽음 처리된 메시지 수
+    private int readCount;
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatMessageRes.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatMessageRes.java
@@ -1,0 +1,30 @@
+package com.skhu.skhucapstone.chat.dto.res;
+
+import com.skhu.skhucapstone.chat.entity.ChatMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatMessageRes {
+
+    private Long chatMessageId;
+    private Long chatRoomId;
+    private Long senderId;
+    private String content;
+    private Boolean isRead;
+    private LocalDateTime createdAt;
+
+    public static ChatMessageRes from(ChatMessage message) {
+        return ChatMessageRes.builder()
+                .chatMessageId(message.getChatMessageId())
+                .chatRoomId(message.getChatRoom().getChatRoomId())
+                .senderId(message.getSender().getUserId())
+                .content(message.getContent())
+                .isRead(message.getIsRead())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatRoomListItemRes.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatRoomListItemRes.java
@@ -1,0 +1,21 @@
+package com.skhu.skhucapstone.chat.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatRoomListItemRes {
+
+    private Long chatRoomId;
+    private Long targetUserId;
+    private String targetUserName;
+    private String targetProfileImage;
+    // 마지막 메시지 내용 (없으면 null)
+    private String lastMessage;
+    // 마지막 메시지 전송 시각 (없으면 null)
+    private LocalDateTime lastMessageAt;
+    private long unreadCount;
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatRoomListRes.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatRoomListRes.java
@@ -1,0 +1,13 @@
+package com.skhu.skhucapstone.chat.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ChatRoomListRes {
+
+    private List<ChatRoomListItemRes> content;
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatRoomRes.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/dto/res/ChatRoomRes.java
@@ -1,0 +1,31 @@
+package com.skhu.skhucapstone.chat.dto.res;
+
+import com.skhu.skhucapstone.chat.entity.ChatRoom;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatRoomRes {
+
+    private Long chatRoomId;
+    private Long user1Id;
+    private Long user2Id;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    // 새로 생성된 채팅방이면 true, 기존 채팅방 반환이면 false
+    private Boolean isNew;
+
+    public static ChatRoomRes of(ChatRoom chatRoom, Boolean isNew) {
+        return ChatRoomRes.builder()
+                .chatRoomId(chatRoom.getChatRoomId())
+                .user1Id(chatRoom.getUser1().getUserId())
+                .user2Id(chatRoom.getUser2().getUserId())
+                .createdAt(chatRoom.getCreatedAt())
+                .updatedAt(chatRoom.getUpdatedAt())
+                .isNew(isNew)
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/entity/ChatMessage.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/entity/ChatMessage.java
@@ -1,0 +1,54 @@
+package com.skhu.skhucapstone.chat.entity;
+
+import com.skhu.skhucapstone.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "chat_message")
+public class ChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatMessageId;
+
+    // 메시지가 속한 채팅방
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+
+    // 메시지 보낸 유저
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
+
+    // 메시지 내용
+    @Column(nullable = false)
+    private String content;
+
+    // 읽음 여부 (기본값 false = 안 읽음)
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isRead = false;
+
+    // 메시지 전송 시각 (한 번만 저장, 이후 변경 불가)
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 엔티티 최초 저장 시 createdAt 자동 설정
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // 읽음 처리 (상대방이 메시지를 읽었을 때 호출)
+    public void markAsRead() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/entity/ChatRoom.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/entity/ChatRoom.java
@@ -1,0 +1,50 @@
+package com.skhu.skhucapstone.chat.entity;
+
+import com.skhu.skhucapstone.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "chat_room")
+public class ChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long chatRoomId;
+
+    // 채팅방을 생성 요청한 유저 (커피챗 신청자)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user1_id", nullable = false)
+    private User user1;
+
+    // 채팅 상대방 (커피챗 대상자)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user2_id", nullable = false)
+    private User user2;
+
+    // 채팅방 생성 시각 (한번만 저장, 이후 변경 불가)
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 마지막 메시지 전송 시각 (채팅방 목록 정렬에 사용)
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // 엔티티 최초 저장 시 createdAt, updatedAt 자동 설정
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    // 메시지 전송 시 채팅방의 updatedAt 갱신 (채팅방 목록 최신순 정렬용)
+    public void updateUpdatedAt() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,32 @@
+package com.skhu.skhucapstone.chat.repository;
+
+import com.skhu.skhucapstone.chat.entity.ChatMessage;
+import com.skhu.skhucapstone.chat.entity.ChatRoom;
+import com.skhu.skhucapstone.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    // 채팅방 메시지 목록 조회 (페이징, 오래된 순 정렬)
+    // 단순 조건 + 정렬이라 메서드명으로 표현 가능
+    Page<ChatMessage> findByChatRoomOrderByCreatedAtAsc(ChatRoom chatRoom, Pageable pageable);
+
+    // 채팅방의 안 읽은 메시지 수 조회 (채팅방 목록에서 unreadCount 표시용)
+    // 상대방이 보낸 메시지 중 아직 읽지 않은 것만 카운트 → 복합 조건이라 @Query 사용
+    @Query("SELECT COUNT(m) FROM ChatMessage m WHERE m.chatRoom = :chatRoom AND m.sender <> :user AND m.isRead = false")
+    long countUnreadMessages(@Param("chatRoom") ChatRoom chatRoom, @Param("user") User user);
+
+    // 채팅방의 가장 마지막 메시지 조회 (채팅방 목록에서 lastMessage 표시용)
+    // JPQL은 LIMIT을 지원하지 않아 메서드 네이밍으로 처리
+    Optional<ChatMessage> findFirstByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom);
+
+    // 읽음 처리 대상 메시지 조회 (messageIds 목록으로 한 번에 조회)
+    List<ChatMessage> findAllByChatMessageIdIn(List<Long> ids);
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,23 @@
+package com.skhu.skhucapstone.chat.repository;
+
+import com.skhu.skhucapstone.chat.entity.ChatRoom;
+import com.skhu.skhucapstone.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    // 두 유저 사이의 채팅방 조회 (채팅방 생성 시 중복 방지용)
+    // user1-user2, user2-user1 양방향 모두 확인해야 해서 @Query 사용
+    @Query("SELECT c FROM ChatRoom c WHERE (c.user1 = :user1 AND c.user2 = :user2) OR (c.user1 = :user2 AND c.user2 = :user1)")
+    Optional<ChatRoom> findByUsers(@Param("user1") User user1, @Param("user2") User user2);
+
+    // 내 채팅방 목록 조회 (최신 메시지 순 정렬)
+    // user1이거나 user2인 채팅방 모두 포함해야 해서 OR 조건 + ORDER BY 필요
+    @Query("SELECT c FROM ChatRoom c WHERE c.user1 = :user OR c.user2 = :user ORDER BY c.updatedAt DESC")
+    List<ChatRoom> findAllByUser(@Param("user") User user);
+}

--- a/src/main/java/com/skhu/skhucapstone/chat/service/ChatService.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/service/ChatService.java
@@ -1,0 +1,177 @@
+package com.skhu.skhucapstone.chat.service;
+
+import com.skhu.skhucapstone.chat.dto.req.ChatMessageReadReq;
+import com.skhu.skhucapstone.chat.dto.req.ChatMessageSendReq;
+import com.skhu.skhucapstone.chat.dto.req.ChatRoomCreateReq;
+import com.skhu.skhucapstone.chat.dto.res.*;
+import com.skhu.skhucapstone.chat.entity.ChatMessage;
+import com.skhu.skhucapstone.chat.entity.ChatRoom;
+import com.skhu.skhucapstone.chat.repository.ChatMessageRepository;
+import com.skhu.skhucapstone.chat.repository.ChatRoomRepository;
+import com.skhu.skhucapstone.common.exception.CustomException;
+import com.skhu.skhucapstone.common.exception.ErrorCode;
+import com.skhu.skhucapstone.user.entity.User;
+import com.skhu.skhucapstone.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
+
+    // 채팅방 생성 or 반환 (이미 존재하면 기존 채팅방 반환)
+    @Transactional
+    public ChatRoomRes createOrGetChatRoom(Long userId, ChatRoomCreateReq req) {
+        // 자기 자신과의 채팅 불가
+        if (userId.equals(req.getTargetUserId())) {
+            throw new CustomException(ErrorCode.CANNOT_CHAT_WITH_SELF);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User targetUser = userRepository.findById(req.getTargetUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 존재하는 채팅방이 있으면 isNew=false로 반환
+        return chatRoomRepository.findByUsers(user, targetUser)
+                .map(existing -> ChatRoomRes.of(existing, false))
+                .orElseGet(() -> {
+                    // 없으면 새로 생성 후 isNew=true로 반환
+                    ChatRoom newRoom = chatRoomRepository.save(
+                            ChatRoom.builder()
+                                    .user1(user)
+                                    .user2(targetUser)
+                                    .build()
+                    );
+                    return ChatRoomRes.of(newRoom, true);
+                });
+    }
+
+    // 내 채팅방 목록 조회 (최신 메시지 순)
+    @Transactional(readOnly = true)
+    public ChatRoomListRes getChatRooms(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<ChatRoomListItemRes> content = chatRoomRepository.findAllByUser(user).stream()
+                .map(room -> {
+                    // 상대방 정보 추출 (내가 user1이면 상대는 user2, 반대도 마찬가지)
+                    User target = room.getUser1().getUserId().equals(userId)
+                            ? room.getUser2()
+                            : room.getUser1();
+
+                    // 마지막 메시지 조회 (없으면 null)
+                    ChatMessage lastMsg = chatMessageRepository.findFirstByChatRoomOrderByCreatedAtDesc(room).orElse(null);
+
+                    // 안 읽은 메시지 수 조회
+                    long unreadCount = chatMessageRepository.countUnreadMessages(room, user);
+
+                    return ChatRoomListItemRes.builder()
+                            .chatRoomId(room.getChatRoomId())
+                            .targetUserId(target.getUserId())
+                            .targetUserName(target.getName())
+                            .targetProfileImage(target.getProfileImage())
+                            .lastMessage(lastMsg != null ? lastMsg.getContent() : null)
+                            .lastMessageAt(lastMsg != null ? lastMsg.getCreatedAt() : null)
+                            .unreadCount(unreadCount)
+                            .build();
+                })
+                .toList();
+
+        return ChatRoomListRes.builder()
+                .content(content)
+                .build();
+    }
+
+    // 메시지 전송
+    @Transactional
+    public ChatMessageRes sendMessage(Long userId, Long chatRoomId, ChatMessageSendReq req) {
+        User sender = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 채팅방 참여자인지 확인
+        validateChatRoomAccess(chatRoom, userId);
+
+        ChatMessage message = chatMessageRepository.save(
+                ChatMessage.builder()
+                        .chatRoom(chatRoom)
+                        .sender(sender)
+                        .content(req.getContent())
+                        .build()
+        );
+
+        // 채팅방 최신 메시지 시각 갱신
+        chatRoom.updateUpdatedAt();
+
+        return ChatMessageRes.from(message);
+    }
+
+    // 채팅방 메시지 목록 조회 (페이징)
+    @Transactional(readOnly = true)
+    public ChatMessageListRes getMessages(Long userId, Long chatRoomId, int page, int size) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 채팅방 참여자인지 확인
+        validateChatRoomAccess(chatRoom, userId);
+
+        return ChatMessageListRes.from(
+                chatMessageRepository.findByChatRoomOrderByCreatedAtAsc(chatRoom, PageRequest.of(page, size))
+                        .map(ChatMessageRes::from)
+        );
+    }
+
+    // 메시지 읽음 처리
+    @Transactional
+    public ChatMessageReadRes readMessages(Long userId, Long chatRoomId, ChatMessageReadReq req) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 채팅방 참여자인지 확인
+        validateChatRoomAccess(chatRoom, userId);
+
+        List<ChatMessage> messages = chatMessageRepository.findAllByChatMessageIdIn(req.getMessageIds());
+
+        // 요청한 messageIds 중 존재하지 않는 것이 있으면 예외
+        if (messages.size() != req.getMessageIds().size()) {
+            throw new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND);
+        }
+
+        // 내가 보낸 메시지는 제외하고, 상대방 메시지만 읽음 처리
+        int readCount = 0;
+        for (ChatMessage message : messages) {
+            if (!message.getSender().getUserId().equals(userId) && !message.getIsRead()) {
+                message.markAsRead();
+                readCount++;
+            }
+        }
+
+        return ChatMessageReadRes.builder()
+                .chatRoomId(chatRoomId)
+                .readCount(readCount)
+                .build();
+    }
+
+    // 채팅방 접근 권한 확인 (user1 또는 user2여야 함)
+    private void validateChatRoomAccess(ChatRoom chatRoom, Long userId) {
+        boolean isParticipant = chatRoom.getUser1().getUserId().equals(userId)
+                || chatRoom.getUser2().getUserId().equals(userId);
+        if (!isParticipant) {
+            throw new CustomException(ErrorCode.CHAT_ROOM_ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
@@ -52,7 +52,14 @@ public enum ErrorCode {
 
 
     // 유저
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),
+
+    // 채팅
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_ROOM_NOT_FOUND", "채팅방을 찾을 수 없습니다."),
+    CHAT_ROOM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CHAT_ROOM_ACCESS_DENIED", "해당 채팅방에 접근할 수 없습니다."),
+    CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT_MESSAGE_NOT_FOUND", "채팅 메시지를 찾을 수 없습니다."),
+    INVALID_MESSAGE_CONTENT(HttpStatus.BAD_REQUEST, "INVALID_MESSAGE_CONTENT", "메시지 내용을 입력해주세요."),
+    CANNOT_CHAT_WITH_SELF(HttpStatus.BAD_REQUEST, "CANNOT_CHAT_WITH_SELF", "자기 자신과는 채팅할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
@@ -44,7 +44,15 @@ public enum SuccessCode {
     CLUB_MEMBER_LIST_GET_SUCCESS(HttpStatus.OK, "CLUB_MEMBER_LIST_GET_SUCCESS", "동아리 멤버 목록 조회가 완료되었습니다."),
 
     // 마이페이지
-    MYPAGE_GET_SUCCESS(HttpStatus.OK, "MYPAGE_GET_SUCCESS", "마이페이지 조회가 완료되었습니다.");
+    MYPAGE_GET_SUCCESS(HttpStatus.OK, "MYPAGE_GET_SUCCESS", "마이페이지 조회가 완료되었습니다."),
+
+    // 채팅
+    CHAT_ROOM_CREATE_SUCCESS(HttpStatus.OK, "CHAT_ROOM_CREATE_SUCCESS", "채팅방이 생성되었습니다."),
+    CHAT_ROOM_ALREADY_EXISTS(HttpStatus.OK, "CHAT_ROOM_ALREADY_EXISTS", "기존 채팅방을 반환합니다."),
+    CHAT_ROOM_LIST_FETCH_SUCCESS(HttpStatus.OK, "CHAT_ROOM_LIST_FETCH_SUCCESS", "채팅방 목록 조회에 성공했습니다."),
+    CHAT_MESSAGE_SEND_SUCCESS(HttpStatus.OK, "CHAT_MESSAGE_SEND_SUCCESS", "메시지 전송에 성공했습니다."),
+    CHAT_MESSAGE_LIST_FETCH_SUCCESS(HttpStatus.OK, "CHAT_MESSAGE_LIST_FETCH_SUCCESS", "채팅 메시지 목록 조회에 성공했습니다."),
+    CHAT_MESSAGE_READ_SUCCESS(HttpStatus.OK, "CHAT_MESSAGE_READ_SUCCESS", "메시지를 읽음 처리했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/security/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                                 "/api/admin/clubs/**",
                                 "/api/clubs/*/members",
                                 "/v3/api-docs/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/ws/**"
                         ).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/skhu/skhucapstone/common/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/skhu/skhucapstone/common/websocket/StompAuthChannelInterceptor.java
@@ -1,0 +1,38 @@
+package com.skhu.skhucapstone.common.websocket;
+
+import com.skhu.skhucapstone.common.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                String token = authHeader.substring(7);
+                if (jwtUtil.isTokenValid(token)) {
+                    Long userId = jwtUtil.getUserId(token);
+                    // Principal에 userId를 저장해 컨트롤러에서 꺼내 쓸 수 있도록 함
+                    accessor.setUser(() -> String.valueOf(userId));
+                }
+            }
+        }
+
+        return message;
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/common/websocket/WebSocketConfig.java
+++ b/src/main/java/com/skhu/skhucapstone/common/websocket/WebSocketConfig.java
@@ -1,0 +1,37 @@
+package com.skhu.skhucapstone.common.websocket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        // 클라이언트가 구독할 prefix (메시지 수신)
+        config.enableSimpleBroker("/topic");
+        // 클라이언트가 메시지를 보낼 때 prefix
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
+    }
+}


### PR DESCRIPTION
## 채팅 기능 구현 #20

### 구현 개요

유저 간 1:1 채팅 기능을 구현했습니다.

---

### 커밋별 작업 내용

#### 1. `feat(AI): ChatRoom, ChatMessage 엔티티 추가`

- `ChatRoom` : user1, user2 두 유저 간의 채팅방, `updatedAt`으로 최신 메시지 순 정렬 지원
- `ChatMessage` : 채팅방에 속한 메시지, `isRead`로 읽음 여부 관리
- `@PrePersist`로 `createdAt`, `updatedAt` 자동 설정
- **AI 구현**

---

#### 2. `feat: 채팅 요청/응답 DTO 추가`

- **직접 작성**

**Request**
| DTO | 설명 |
|-----|------|
| `ChatRoomCreateReq` | 채팅 상대방 userId |
| `ChatMessageSendReq` | 메시지 내용 (빈 값 불가 검증) |
| `ChatMessageReadReq` | 읽음 처리할 messageId 목록 |

**Response**
| DTO | 설명 |
|-----|------|
| `ChatRoomRes` | 채팅방 정보 + isNew 플래그 |
| `ChatRoomListRes` | 채팅방 목록 |
| `ChatRoomListItemRes` | 채팅방 목록 단건 (상대방 정보, 마지막 메시지, 안읽은 수) |
| `ChatMessageRes` | 메시지 단건 |
| `ChatMessageListRes` | 메시지 목록 + 페이징 정보 |
| `ChatMessageReadRes` | 읽음 처리된 메시지 수 |

---

#### 3. `feat(AI): ChatRoom, ChatMessage 레포지토리 추가`

- `ChatRoomRepository` : 양방향 채팅방 조회(`findByUsers`), 내 채팅방 목록 최신순 조회
- `ChatMessageRepository` : 페이징 메시지 조회, 읽지 않은 메시지 수 카운트, 마지막 메시지 조회
- **AI 구현**

> **AI 코드를 직접 수정한 부분**
>
> AI가 생성한 `findAllByIdIn(List<Long> ids)` 메서드가 빌드 시 오류를 발생시켰습니다.
> `ChatMessage` 엔티티의 PK 필드명이 `id`가 아닌 `chatMessageId`임을 직접 파악하고
> `findAllByChatMessageIdIn`으로 수정하여 Spring Data JPA 네이밍 규칙에 맞게 교정했습니다.

---

#### 4. `feat(AI): 채팅 서비스 구현`

- 채팅방 생성 시 중복 방지 (이미 존재하면 기존 방 반환, `isNew` 플래그로 구분)
- 채팅방 접근 권한 검증 (`validateChatRoomAccess`)
- 읽음 처리 시 내가 보낸 메시지는 제외하고 상대방 메시지만 처리
- **AI 구현**

> **AI 코드를 직접 수정한 부분**
>
> AI가 `Boolean` 타입에 null이 들어올 수 있다는 이유로 `Boolean.FALSE.equals()` 방어 코드를 추가했으나,
> 직접 엔티티를 확인하여 `@Column(nullable = false)`와 `@Builder.Default`로 null이 불가능함을 파악하고
> 불필요한 방어 코드를 제거하여 `!message.getIsRead()` 방식으로 되돌렸습니다.

---

#### 5. `feat: 채팅 컨트롤러 구현`

- **직접 작성**

| 메서드 | 엔드포인트 | 설명 |
|--------|-----------|------|
| `POST` | `/api/chat/rooms` | 채팅방 생성 or 기존 반환 |
| `GET` | `/api/chat/rooms` | 내 채팅방 목록 조회 |
| `GET` | `/api/chat/rooms/{chatRoomId}/messages` | 메시지 목록 조회 (페이징) |
| `PATCH` | `/api/chat/rooms/{chatRoomId}/read` | 메시지 읽음 처리 |

---

#### 6. `feat(AI): 채팅 관련 ErrorCode, SuccessCode 추가`

**ErrorCode**
| 코드 | 설명 |
|------|------|
| `CHAT_ROOM_NOT_FOUND` | 채팅방을 찾을 수 없음 |
| `CHAT_ROOM_ACCESS_DENIED` | 채팅방 접근 권한 없음 |
| `CHAT_MESSAGE_NOT_FOUND` | 채팅 메시지를 찾을 수 없음 |
| `CANNOT_CHAT_WITH_SELF` | 자기 자신과 채팅 불가 |

**SuccessCode**
| 코드 | 설명 |
|------|------|
| `CHAT_ROOM_CREATE_SUCCESS` | 채팅방 생성 성공 |
| `CHAT_ROOM_ALREADY_EXISTS` | 기존 채팅방 반환 |
| `CHAT_ROOM_LIST_FETCH_SUCCESS` | 채팅방 목록 조회 성공 |
| `CHAT_MESSAGE_LIST_FETCH_SUCCESS` | 메시지 목록 조회 성공 |
| `CHAT_MESSAGE_READ_SUCCESS` | 읽음 처리 성공 |

---

#### 7. `feat(AI): WebSocket(STOMP) 기반 실시간 채팅 구현`

- **AI 구현**

| 파일 | 설명 |
|------|------|
| `WebSocketConfig` | STOMP 엔드포인트(`/ws`) 등록, Simple Broker 설정 |
| `StompAuthChannelInterceptor` | CONNECT 프레임에서 JWT 토큰 추출 후 `Principal` 등록 |
| `ChatWebSocketController` | `/app/chat/{chatRoomId}/send` 수신 후 `/topic/chat/{chatRoomId}`로 브로드캐스트 |

- 기존 `POST /api/chat/rooms/{chatRoomId}/messages` REST API는 WebSocket으로 대체되어 주석 처리
- 메시지 전송 시 DB 저장 후 채팅방 구독자 전체에게 실시간 브로드캐스트

---

### 테스트

#### REST API - Swagger UI(`http://localhost:8080/swagger-ui.html`)

**채팅방 생성**
- 유저 A로 로그인 후 유저 B의 userId로 `POST /api/chat/rooms` 요청
- 응답 `isNew: true`, `chatRoomId` 반환 확인
- 동일한 요청 재시도 시 `isNew: false`로 기존 채팅방 반환 확인

**메시지 목록 조회**
- `GET /api/chat/rooms/{chatRoomId}/messages?page=0&size=20`
- 전송한 메시지가 목록에 포함되는지 확인
- `totalElements`, `totalPages` 페이징 정보 확인

**읽음 처리**
- `PATCH /api/chat/rooms/{chatRoomId}/read`에 `messageIds` 배열 전달
- 응답 `readCount` 값이 처리된 메시지 수와 일치하는지 확인
- 내가 보낸 메시지는 `readCount`에 포함되지 않는 것 확인

**채팅방 목록 조회**
- `GET /api/chat/rooms`로 내 채팅방 목록 조회
- `lastMessage`, `lastMessageAt`, `unreadCount` 정상 반환 확인
- 최신 메시지 순으로 정렬되는 것 확인

**예외 처리**
- 자기 자신 userId로 채팅방 생성 시 `CANNOT_CHAT_WITH_SELF` 에러 반환 확인
- 참여하지 않은 채팅방 접근 시 `CHAT_ROOM_ACCESS_DENIED` 에러 반환 확인
- 존재하지 않는 `messageId`로 읽음 처리 시 `CHAT_MESSAGE_NOT_FOUND` 에러 반환 확인

#### WebSocket - HTML 테스트 파일
<img width="757" height="673" alt="image" src="https://github.com/user-attachments/assets/848a298e-50e2-44c1-ad1e-5d853fb79276" />

- SockJS + STOMP 클라이언트로 `http://localhost:8080/ws` 연결
- CONNECT 프레임에 `Authorization: Bearer {token}` 헤더 포함
- `/topic/chat/{chatRoomId}` 구독 후 `/app/chat/{chatRoomId}/send`로 메시지 전송
- 브라우저 콘솔에서 `CONNECTED` → `SUBSCRIBE` → `SEND` → `MESSAGE` 수신 순서 확인
- 응답 데이터 `chatMessageId`, `chatRoomId`, `content`, `isRead`, `senderId` 정상 반환 확인

---

### 추후 디벨롭 예정

- **사용자 현재 활동 상태 표시** : 유저가 온라인/오프라인 상태인지 실시간으로 표시