### PR TITLE
Feat/31 club collaboration

### DIFF
--- a/src/main/java/com/skhu/skhucapstone/chat/service/ChatService.java
+++ b/src/main/java/com/skhu/skhucapstone/chat/service/ChatService.java
@@ -54,6 +54,36 @@ public class ChatService {
                     return ChatRoomRes.of(newRoom, true);
                 });
     }
+    // 협업 모집글 문의하기 등 내부 서비스에서 targetUserId를 바로 알고 있을 때 사용하는 채팅방 생성/반환 메서드
+    // 기존 createOrGetChatRoom(Long userId, ChatRoomCreateReq req)는 컨트롤러 요청용으로 유지하고,
+    // 이 메서드는 DTO 생성 없이 userId와 targetUserId만으로 기존 채팅방을 찾거나 새 채팅방을 생성한다.    @Transactional
+    public ChatRoomRes createOrGetChatRoom(
+            Long userId,
+            Long targetUserId
+    ) {
+        if (userId.equals(targetUserId)) {
+            throw new CustomException(ErrorCode.CANNOT_CHAT_WITH_SELF);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return chatRoomRepository.findByUsers(user, targetUser)
+                .map(existing -> ChatRoomRes.of(existing, false))
+                .orElseGet(() -> {
+                    ChatRoom newRoom = chatRoomRepository.save(
+                            ChatRoom.builder()
+                                    .user1(user)
+                                    .user2(targetUser)
+                                    .build()
+                    );
+
+                    return ChatRoomRes.of(newRoom, true);
+                });
+    }
 
     // 내 채팅방 목록 조회 (최신 메시지 순)
     @Transactional(readOnly = true)

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/ClubCollabController.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/ClubCollabController.java
@@ -38,12 +38,13 @@ public class ClubCollabController {
     }
 
     @GetMapping
-    @Operation(summary = "협업 모집글 목록 조회", description = "협업 모집글을 최신순으로 페이지 단위 조회합니다.")
+    @Operation(summary = "협업 모집글 목록 조회", description = "협업 모집글을 최신순으로 페이지 단위 조회하고, 키워드 검색을 지원합니다.")
     public ResponseEntity<ApiResponse<ClubCollabPageResponse>> getCollabs(
+            @RequestParam(required = false) String keyword,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        ClubCollabPageResponse response = clubCollabService.getCollabs(page, size);
+        ClubCollabPageResponse response = clubCollabService.getCollabs(keyword, page, size);
 
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.CLUB_COLLAB_LIST_GET_SUCCESS, response)

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/ClubCollabController.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/ClubCollabController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.response.ClubCollabApplyResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -85,6 +86,26 @@ public class ClubCollabController {
 
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.CLUB_COLLAB_DELETE_SUCCESS, null)
+        );
+    }
+
+    @PostMapping("/{collabId}/apply")
+    @Operation(
+            summary = "협업 모집 문의하기",
+            description = "협업 모집글 작성자와 채팅방을 생성하거나 기존 채팅방을 반환합니다."
+    )
+    public ResponseEntity<ApiResponse<ClubCollabApplyResponse>> applyCollab(
+            @PathVariable Long collabId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        ClubCollabApplyResponse response =
+                clubCollabService.applyCollab(collabId, userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(
+                        SuccessCode.CLUB_COLLAB_APPLY_SUCCESS,
+                        response
+                )
         );
     }
 }

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/ClubCollabController.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/ClubCollabController.java
@@ -1,0 +1,90 @@
+package com.skhu.skhucapstone.clubcollaboration.api;
+
+import com.skhu.skhucapstone.clubcollaboration.api.dto.request.ClubCollabCreateRequest;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.request.ClubCollabUpdateRequest;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.response.ClubCollabPageResponse;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.response.ClubCollabResponse;
+import com.skhu.skhucapstone.clubcollaboration.application.ClubCollabService;
+import com.skhu.skhucapstone.common.exception.SuccessCode;
+import com.skhu.skhucapstone.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/club-collaborations")
+@Tag(name = "ClubCollab", description = "동아리 협업 모집 API")
+public class ClubCollabController {
+
+    private final ClubCollabService clubCollabService;
+
+    @PostMapping
+    @Operation(summary = "협업 모집글 작성", description = "해당 동아리의 STAFF 또는 PRESIDENT만 협업 모집글을 작성할 수 있습니다.")
+    public ResponseEntity<ApiResponse<ClubCollabResponse>> createCollab(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid ClubCollabCreateRequest request
+    ) {
+        ClubCollabResponse response = clubCollabService.createCollab(userId, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.CLUB_COLLAB_CREATE_SUCCESS, response)
+        );
+    }
+
+    @GetMapping
+    @Operation(summary = "협업 모집글 목록 조회", description = "협업 모집글을 최신순으로 페이지 단위 조회합니다.")
+    public ResponseEntity<ApiResponse<ClubCollabPageResponse>> getCollabs(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        ClubCollabPageResponse response = clubCollabService.getCollabs(page, size);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.CLUB_COLLAB_LIST_GET_SUCCESS, response)
+        );
+    }
+
+    @GetMapping("/{collabId}")
+    @Operation(summary = "협업 모집글 상세 조회", description = "협업 모집글 ID로 상세 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<ClubCollabResponse>> getCollab(
+            @PathVariable Long collabId
+    ) {
+        ClubCollabResponse response = clubCollabService.getCollab(collabId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.CLUB_COLLAB_DETAIL_GET_SUCCESS, response)
+        );
+    }
+
+    @PatchMapping("/{collabId}")
+    @Operation(summary = "협업 모집글 수정", description = "협업 모집글 작성자 본인만 수정할 수 있습니다.")
+    public ResponseEntity<ApiResponse<ClubCollabResponse>> updateCollab(
+            @PathVariable Long collabId,
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid ClubCollabUpdateRequest request
+    ) {
+        ClubCollabResponse response = clubCollabService.updateCollab(collabId, userId, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.CLUB_COLLAB_UPDATE_SUCCESS, response)
+        );
+    }
+
+    @DeleteMapping("/{collabId}")
+    @Operation(summary = "협업 모집글 삭제", description = "협업 모집글 작성자 본인만 삭제할 수 있습니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteCollab(
+            @PathVariable Long collabId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        clubCollabService.deleteCollab(collabId, userId);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.CLUB_COLLAB_DELETE_SUCCESS, null)
+        );
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabCreateRequest.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabCreateRequest.java
@@ -1,0 +1,32 @@
+package com.skhu.skhucapstone.clubcollaboration.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record ClubCollabCreateRequest(
+
+        @NotNull(message = "동아리 ID는 필수입니다.")
+        Long clubId,
+
+        @NotBlank(message = "협업 모집글 제목은 필수입니다.")
+        @Size(max = 100, message = "협업 모집글 제목은 100자 이하로 입력해주세요.")
+        String title,
+
+        @NotBlank(message = "대회명은 필수입니다.")
+        @Size(max = 100, message = "대회명은 100자 이하로 입력해주세요.")
+        String contestName,
+
+        @NotNull(message = "대회 날짜는 필수입니다.")
+        LocalDate contestDate,
+
+        @NotBlank(message = "협업 모집글 내용은 필수입니다.")
+        @Size(max = 3000, message = "협업 모집글 내용은 3000자 이하로 입력해주세요.")
+        String content,
+
+        @NotNull(message = "마감일은 필수입니다.")
+        LocalDate deadline
+) {
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabCreateRequest.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabCreateRequest.java
@@ -15,6 +15,8 @@ public record ClubCollabCreateRequest(
         @Size(max = 100, message = "협업 모집글 제목은 100자 이하로 입력해주세요.")
         String title,
 
+        String imageUrl,
+
         @NotBlank(message = "대회명은 필수입니다.")
         @Size(max = 100, message = "대회명은 100자 이하로 입력해주세요.")
         String contestName,

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabUpdateRequest.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.skhu.skhucapstone.clubcollaboration.api.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record ClubCollabUpdateRequest(
+
+        @NotBlank(message = "협업 모집글 제목은 필수입니다.")
+        @Size(max = 100, message = "협업 모집글 제목은 100자 이하로 입력해주세요.")
+        String title,
+
+        @NotBlank(message = "대회명은 필수입니다.")
+        @Size(max = 100, message = "대회명은 100자 이하로 입력해주세요.")
+        String contestName,
+
+        @NotNull(message = "대회 날짜는 필수입니다.")
+        LocalDate contestDate,
+
+        @NotBlank(message = "협업 모집글 내용은 필수입니다.")
+        @Size(max = 3000, message = "협업 모집글 내용은 3000자 이하로 입력해주세요.")
+        String content,
+
+        @NotNull(message = "마감일은 필수입니다.")
+        LocalDate deadline
+) {
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabUpdateRequest.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/request/ClubCollabUpdateRequest.java
@@ -12,6 +12,8 @@ public record ClubCollabUpdateRequest(
         @Size(max = 100, message = "협업 모집글 제목은 100자 이하로 입력해주세요.")
         String title,
 
+        String imageUrl,
+
         @NotBlank(message = "대회명은 필수입니다.")
         @Size(max = 100, message = "대회명은 100자 이하로 입력해주세요.")
         String contestName,

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabApplyResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabApplyResponse.java
@@ -1,0 +1,17 @@
+package com.skhu.skhucapstone.clubcollaboration.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ClubCollabApplyResponse {
+
+    private Long collabId;
+
+    private String title;
+
+    private Long chatRoomId;
+
+    private Boolean isNew;
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabPageResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabPageResponse.java
@@ -1,0 +1,23 @@
+package com.skhu.skhucapstone.clubcollaboration.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ClubCollabPageResponse {
+
+    private List<ClubCollabResponse> content;
+
+    private int page;
+
+    private int size;
+
+    private long totalElements;
+
+    private int totalPages;
+
+    private boolean last;
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabResponse.java
@@ -18,6 +18,8 @@ public class ClubCollabResponse {
 
     private String title;
 
+    private String imageUrl;
+
     private String contestName;
 
     private LocalDate contestDate;

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/api/dto/response/ClubCollabResponse.java
@@ -1,0 +1,34 @@
+package com.skhu.skhucapstone.clubcollaboration.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ClubCollabResponse {
+
+    private Long collabId;
+
+    private Long clubId;
+
+    private String clubName;
+
+    private String title;
+
+    private String contestName;
+
+    private LocalDate contestDate;
+
+    private String content;
+
+    private LocalDate deadline;
+
+    private String dDayText;
+
+    private String writerName;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
@@ -21,6 +21,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.skhu.skhucapstone.chat.dto.res.ChatRoomRes;
+import com.skhu.skhucapstone.chat.service.ChatService;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.response.ClubCollabApplyResponse;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -35,6 +38,7 @@ public class ClubCollabService {
     private final ClubRepository clubRepository;
     private final UserRepository userRepository;
     private final ClubMemberRepository clubMemberRepository;
+    private final ChatService chatService;
 
     @Transactional
     public ClubCollabResponse createCollab(
@@ -128,6 +132,27 @@ public class ClubCollabService {
         validateCollabWriter(collab, userId, ErrorCode.CLUB_COLLAB_DELETE_FORBIDDEN);
 
         clubCollabRepository.delete(collab);
+    }
+
+    @Transactional
+    public ClubCollabApplyResponse applyCollab(
+            Long collabId,
+            Long userId
+    ) {
+        ClubCollaboration collab = clubCollabRepository.findById(collabId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_COLLAB_NOT_FOUND));
+
+        ChatRoomRes chatRoom = chatService.createOrGetChatRoom(
+                userId,
+                collab.getUser().getUserId()
+        );
+
+        return ClubCollabApplyResponse.builder()
+                .collabId(collab.getCollabId())
+                .title(collab.getTitle())
+                .chatRoomId(chatRoom.getChatRoomId())
+                .isNew(chatRoom.getIsNew())
+                .build();
     }
 
     private void validateCollabWritePermission(Club club, User user) {

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
@@ -1,0 +1,176 @@
+package com.skhu.skhucapstone.clubcollaboration.application;
+
+import com.skhu.skhucapstone.club.domain.Club;
+import com.skhu.skhucapstone.club.domain.repository.ClubRepository;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.request.ClubCollabCreateRequest;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.request.ClubCollabUpdateRequest;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.response.ClubCollabPageResponse;
+import com.skhu.skhucapstone.clubcollaboration.api.dto.response.ClubCollabResponse;
+import com.skhu.skhucapstone.clubcollaboration.domain.ClubCollaboration;
+import com.skhu.skhucapstone.clubcollaboration.domain.repository.ClubCollabRepository;
+import com.skhu.skhucapstone.clubmember.domain.ClubMember;
+import com.skhu.skhucapstone.clubmember.domain.ClubRole;
+import com.skhu.skhucapstone.clubmember.domain.repository.ClubMemberRepository;
+import com.skhu.skhucapstone.common.exception.CustomException;
+import com.skhu.skhucapstone.common.exception.ErrorCode;
+import com.skhu.skhucapstone.user.entity.User;
+import com.skhu.skhucapstone.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubCollabService {
+
+    private final ClubCollabRepository clubCollabRepository;
+    private final ClubRepository clubRepository;
+    private final UserRepository userRepository;
+    private final ClubMemberRepository clubMemberRepository;
+
+    @Transactional
+    public ClubCollabResponse createCollab(
+            Long userId,
+            ClubCollabCreateRequest request
+    ) {
+        Club club = clubRepository.findById(request.clubId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        validateCollabWritePermission(club, user);
+
+        ClubCollaboration clubCollaboration = ClubCollaboration.builder()
+                .title(request.title())
+                .contestName(request.contestName())
+                .contestDate(request.contestDate())
+                .content(request.content())
+                .deadline(request.deadline())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .club(club)
+                .user(user)
+                .build();
+
+        ClubCollaboration savedCollab = clubCollabRepository.save(clubCollaboration);
+
+        return toCollabResponse(savedCollab);
+    }
+
+    public ClubCollabPageResponse getCollabs(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<ClubCollaboration> collabs =
+                clubCollabRepository.findAllByOrderByCreatedAtDesc(pageable);
+
+        return ClubCollabPageResponse.builder()
+                .content(collabs.getContent()
+                        .stream()
+                        .map(this::toCollabResponse)
+                        .toList())
+                .page(collabs.getNumber())
+                .size(collabs.getSize())
+                .totalElements(collabs.getTotalElements())
+                .totalPages(collabs.getTotalPages())
+                .last(collabs.isLast())
+                .build();
+    }
+
+    public ClubCollabResponse getCollab(Long collabId) {
+        ClubCollaboration collab = clubCollabRepository.findById(collabId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_COLLAB_NOT_FOUND));
+
+        return toCollabResponse(collab);
+    }
+
+    @Transactional
+    public ClubCollabResponse updateCollab(
+            Long collabId,
+            Long userId,
+            ClubCollabUpdateRequest request
+    ) {
+        ClubCollaboration collab = clubCollabRepository.findById(collabId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_COLLAB_NOT_FOUND));
+
+        validateCollabWriter(collab, userId, ErrorCode.CLUB_COLLAB_UPDATE_FORBIDDEN);
+
+        collab.updateCollab(
+                request.title(),
+                request.contestName(),
+                request.contestDate(),
+                request.content(),
+                request.deadline()
+        );
+
+        return toCollabResponse(collab);
+    }
+
+    @Transactional
+    public void deleteCollab(Long collabId, Long userId) {
+        ClubCollaboration collab = clubCollabRepository.findById(collabId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_COLLAB_NOT_FOUND));
+
+        validateCollabWriter(collab, userId, ErrorCode.CLUB_COLLAB_DELETE_FORBIDDEN);
+
+        clubCollabRepository.delete(collab);
+    }
+
+    private void validateCollabWritePermission(Club club, User user) {
+        ClubMember clubMember = clubMemberRepository.findByClubAndUser(club, user)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_COLLAB_WRITE_FORBIDDEN));
+
+        if (clubMember.getRole() != ClubRole.STAFF &&
+                clubMember.getRole() != ClubRole.PRESIDENT) {
+            throw new CustomException(ErrorCode.CLUB_COLLAB_WRITE_FORBIDDEN);
+        }
+    }
+
+    private void validateCollabWriter(
+            ClubCollaboration collab,
+            Long userId,
+            ErrorCode errorCode
+    ) {
+        if (!collab.getUser().getUserId().equals(userId)) {
+            throw new CustomException(errorCode);
+        }
+    }
+
+    private ClubCollabResponse toCollabResponse(ClubCollaboration collab) {
+        return ClubCollabResponse.builder()
+                .collabId(collab.getCollabId())
+                .clubId(collab.getClub().getId())
+                .clubName(collab.getClub().getClubName())
+                .title(collab.getTitle())
+                .contestName(collab.getContestName())
+                .contestDate(collab.getContestDate())
+                .content(collab.getContent())
+                .deadline(collab.getDeadline())
+                .dDayText(calculateDday(collab.getDeadline()))
+                .writerName(collab.getUser().getName())
+                .createdAt(collab.getCreatedAt())
+                .build();
+    }
+
+    private String calculateDday(LocalDate deadline) {
+        long days = ChronoUnit.DAYS.between(LocalDate.now(), deadline);
+
+        if (days > 0) {
+            return "D-" + days;
+        }
+
+        if (days == 0) {
+            return "D-DAY";
+        }
+
+        return "마감";
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
@@ -73,11 +73,19 @@ public class ClubCollabService {
         return toCollabResponse(savedCollab);
     }
 
-    public ClubCollabPageResponse getCollabs(int page, int size) {
+    public ClubCollabPageResponse getCollabs(
+            String keyword,
+            int page,
+            int size
+    ) {
         Pageable pageable = PageRequest.of(page, size);
 
+        String searchKeyword = (keyword == null || keyword.isBlank())
+                ? null
+                : keyword;
+
         Page<ClubCollaboration> collabs =
-                clubCollabRepository.findAllByOrderByCreatedAtDesc(pageable);
+                clubCollabRepository.searchCollabs(searchKeyword, pageable);
 
         return ClubCollabPageResponse.builder()
                 .content(collabs.getContent()

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
@@ -144,6 +144,9 @@ public class ClubCollabService {
         if (deadline.isAfter(contestDate)){
             throw new CustomException(ErrorCode.CLUB_COLLAB_INVALID_DATE);
         }
+        if (deadline.isBefore(LocalDate.now())) {
+            throw new CustomException(ErrorCode.CLUB_COLLAB_DEADLINE_PASSED);
+        }
     }
 
 

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
@@ -49,6 +49,8 @@ public class ClubCollabService {
 
         validateCollabWritePermission(club, user);
 
+        validateDate(request.contestDate(), request.deadline());
+
         ClubCollaboration clubCollaboration = ClubCollaboration.builder()
                 .title(request.title())
                 .contestName(request.contestName())
@@ -104,6 +106,8 @@ public class ClubCollabService {
 
         validateCollabWriter(collab, userId, ErrorCode.CLUB_COLLAB_UPDATE_FORBIDDEN);
 
+        validateDate(request.contestDate(), request.deadline());
+
         collab.updateCollab(
                 request.title(),
                 request.contestName(),
@@ -135,6 +139,13 @@ public class ClubCollabService {
             throw new CustomException(ErrorCode.CLUB_COLLAB_WRITE_FORBIDDEN);
         }
     }
+
+    private void validateDate(LocalDate contestDate, LocalDate deadline){
+        if (deadline.isAfter(contestDate)){
+            throw new CustomException(ErrorCode.CLUB_COLLAB_INVALID_DATE);
+        }
+    }
+
 
     private void validateCollabWriter(
             ClubCollaboration collab,

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/application/ClubCollabService.java
@@ -55,6 +55,7 @@ public class ClubCollabService {
                 .contestDate(request.contestDate())
                 .content(request.content())
                 .deadline(request.deadline())
+                .imageUrl(request.imageUrl())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .club(club)
@@ -108,7 +109,8 @@ public class ClubCollabService {
                 request.contestName(),
                 request.contestDate(),
                 request.content(),
-                request.deadline()
+                request.deadline(),
+                request.imageUrl()
         );
 
         return toCollabResponse(collab);
@@ -150,6 +152,7 @@ public class ClubCollabService {
                 .clubId(collab.getClub().getId())
                 .clubName(collab.getClub().getClubName())
                 .title(collab.getTitle())
+                .imageUrl(collab.getImageUrl())
                 .contestName(collab.getContestName())
                 .contestDate(collab.getContestDate())
                 .content(collab.getContent())

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/ClubCollaboration.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/ClubCollaboration.java
@@ -34,6 +34,9 @@ public class ClubCollaboration {
     @Column(nullable = false)
     private LocalDate deadline;
 
+    @Column(length = 1000)
+    private String imageUrl;
+
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
@@ -53,13 +56,16 @@ public class ClubCollaboration {
             String contestName,
             LocalDate contestDate,
             String content,
-            LocalDate deadline
-    ) {
+            LocalDate deadline,
+            String imageUrl
+    )
+    {
         this.title = title;
         this.contestName = contestName;
         this.contestDate = contestDate;
         this.content = content;
         this.deadline = deadline;
+        this.imageUrl = imageUrl;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/ClubCollaboration.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/ClubCollaboration.java
@@ -1,0 +1,65 @@
+package com.skhu.skhucapstone.clubcollaboration.domain;
+
+import com.skhu.skhucapstone.club.domain.Club;
+import com.skhu.skhucapstone.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ClubCollaboration {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long collabId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, length = 100)
+    private String contestName;
+
+    @Column(nullable = false)
+    private LocalDate contestDate;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDate deadline;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public void updateCollab(
+            String title,
+            String contestName,
+            LocalDate contestDate,
+            String content,
+            LocalDate deadline
+    ) {
+        this.title = title;
+        this.contestName = contestName;
+        this.contestDate = contestDate;
+        this.content = content;
+        this.deadline = deadline;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/repository/ClubCollabRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/repository/ClubCollabRepository.java
@@ -1,11 +1,11 @@
 package com.skhu.skhucapstone.clubcollaboration.domain.repository;
 
 import com.skhu.skhucapstone.clubcollaboration.domain.ClubCollaboration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface ClubCollabRepository extends JpaRepository<ClubCollaboration, Long> {
 
-    List<ClubCollaboration> findAllByOrderByCreatedAtDesc();
+    Page<ClubCollaboration> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/repository/ClubCollabRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/repository/ClubCollabRepository.java
@@ -1,0 +1,11 @@
+package com.skhu.skhucapstone.clubcollaboration.domain.repository;
+
+import com.skhu.skhucapstone.clubcollaboration.domain.ClubCollaboration;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ClubCollabRepository extends JpaRepository<ClubCollaboration, Long> {
+
+    List<ClubCollaboration> findAllByOrderByCreatedAtDesc();
+}

--- a/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/repository/ClubCollabRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/clubcollaboration/domain/repository/ClubCollabRepository.java
@@ -4,8 +4,24 @@ import com.skhu.skhucapstone.clubcollaboration.domain.ClubCollaboration;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClubCollabRepository extends JpaRepository<ClubCollaboration, Long> {
 
     Page<ClubCollaboration> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("""
+        SELECT c FROM ClubCollaboration c
+        WHERE (:keyword IS NULL
+            OR c.title LIKE CONCAT('%', :keyword, '%')
+            OR c.content LIKE CONCAT('%', :keyword, '%')
+            OR c.contestName LIKE CONCAT('%', :keyword, '%')
+            OR c.club.clubName LIKE CONCAT('%', :keyword, '%'))
+        ORDER BY c.createdAt DESC
+        """)
+    Page<ClubCollaboration> searchCollabs(
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     CLUB_COLLAB_WRITE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_WRITE_FORBIDDEN", "협업 모집글 작성 권한이 없습니다."),
     CLUB_COLLAB_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_UPDATE_FORBIDDEN", "협업 모집글 수정 권한이 없습니다."),
     CLUB_COLLAB_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_DELETE_FORBIDDEN", "협업 모집글 삭제 권한이 없습니다."),
+    CLUB_COLLAB_INVALID_DATE(HttpStatus.BAD_REQUEST, "CLUB_COLLAB_INVALID_DATE", "마감일은 대회 날짜보다 늦을 수 없습니다."),
 
     // 댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다."),

--- a/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
@@ -46,6 +46,12 @@ public enum ErrorCode {
     POST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_UPDATE_FORBIDDEN", "게시글 수정 권한이 없습니다."),
     POST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "POST_DELETE_FORBIDDEN", "게시글 삭제 권한이 없습니다."),
 
+    // 협업모집
+    CLUB_COLLAB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_COLLAB_NOT_FOUND", "협업 모집글을 찾을 수 없습니다."),
+    CLUB_COLLAB_WRITE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_WRITE_FORBIDDEN", "협업 모집글 작성 권한이 없습니다."),
+    CLUB_COLLAB_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_UPDATE_FORBIDDEN", "협업 모집글 수정 권한이 없습니다."),
+    CLUB_COLLAB_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_DELETE_FORBIDDEN", "협업 모집글 삭제 권한이 없습니다."),
+
     // 댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다."),
     COMMENT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT_DELETE_FORBIDDEN", "댓글 삭제 권한이 없습니다."),

--- a/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     CLUB_COLLAB_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_UPDATE_FORBIDDEN", "협업 모집글 수정 권한이 없습니다."),
     CLUB_COLLAB_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_COLLAB_DELETE_FORBIDDEN", "협업 모집글 삭제 권한이 없습니다."),
     CLUB_COLLAB_INVALID_DATE(HttpStatus.BAD_REQUEST, "CLUB_COLLAB_INVALID_DATE", "마감일은 대회 날짜보다 늦을 수 없습니다."),
+    CLUB_COLLAB_DEADLINE_PASSED(HttpStatus.BAD_REQUEST, "CLUB_COLLAB_DEADLINE_PASSED", "이미 지난 날짜로는 협업 모집글 작성이 불가 합니다."),
 
     // 댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다."),

--- a/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
@@ -49,6 +49,7 @@ public enum SuccessCode {
     CLUB_COLLAB_DETAIL_GET_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_DETAIL_GET_SUCCESS", "협업 모집글 상세 조회가 완료되었습니다."),
     CLUB_COLLAB_UPDATE_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_UPDATE_SUCCESS", "협업 모집글 수정이 완료되었습니다."),
     CLUB_COLLAB_DELETE_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_DELETE_SUCCESS", "협업 모집글 삭제가 완료되었습니다."),
+    CLUB_COLLAB_APPLY_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_APPLY_SUCCESS", "협업 모집 문의가 완료되었습니다."),
 
     // 마이페이지
     MYPAGE_GET_SUCCESS(HttpStatus.OK, "MYPAGE_GET_SUCCESS", "마이페이지 조회가 완료되었습니다."),

--- a/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
@@ -43,6 +43,13 @@ public enum SuccessCode {
     // ClubMember
     CLUB_MEMBER_LIST_GET_SUCCESS(HttpStatus.OK, "CLUB_MEMBER_LIST_GET_SUCCESS", "동아리 멤버 목록 조회가 완료되었습니다."),
 
+    // 협업모집
+    CLUB_COLLAB_CREATE_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_CREATE_SUCCESS", "협업 모집글 작성이 완료되었습니다."),
+    CLUB_COLLAB_LIST_GET_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_LIST_GET_SUCCESS", "협업 모집글 목록 조회가 완료되었습니다."),
+    CLUB_COLLAB_DETAIL_GET_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_DETAIL_GET_SUCCESS", "협업 모집글 상세 조회가 완료되었습니다."),
+    CLUB_COLLAB_UPDATE_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_UPDATE_SUCCESS", "협업 모집글 수정이 완료되었습니다."),
+    CLUB_COLLAB_DELETE_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_DELETE_SUCCESS", "협업 모집글 삭제가 완료되었습니다."),
+
     // 마이페이지
     MYPAGE_GET_SUCCESS(HttpStatus.OK, "MYPAGE_GET_SUCCESS", "마이페이지 조회가 완료되었습니다.");
 


### PR DESCRIPTION
# feat/31-club-collaboration

## 작업 내용

동아리 협업 모집 기능을 구현했습니다.

### 구현 API

* POST /api/club-collaborations
* GET /api/club-collaborations
* GET /api/club-collaborations/{collabId}
* PATCH /api/club-collaborations/{collabId}
* DELETE /api/club-collaborations/{collabId}
* POST /api/club-collaborations/{collabId}/apply

---

## 주요 구현 사항

### 협업 모집글 CRUD

협업 모집글 생성, 조회, 수정, 삭제 기능을 구현했습니다.

협업 모집글에는 아래 정보를 저장합니다.

* 제목
* 대회명
* 대회 날짜
* 내용
* 모집 마감일
* 이미지 URL
* 작성 동아리
* 작성자

---

### 권한 처리

협업 모집글 작성

* 해당 동아리 STAFF
* 해당 동아리 PRESIDENT

만 가능합니다.

협업 모집글 수정

* 작성자 본인만 가능

협업 모집글 삭제

* 작성자 본인만 가능

---

### D-Day 계산

마감일까지 남은 기간을 계산하여 응답에 포함하도록 구현했습니다.

예시

* D-5
* D-DAY
* 마감

---

### 날짜 검증

아래 경우 예외 처리하도록 구현했습니다.

1. 마감일이 대회 날짜보다 늦은 경우

예시

* contestDate: 2026-11-01
* deadline: 2026-12-01

2. 마감일이 오늘보다 이전인 경우

예시

* deadline: 2025-01-01

---

### 이미지 필드 추가

초기 구현 이후 협업 모집글 이미지 요구사항이 확인되어 imageUrl 필드를 추가했습니다.

---

### 검색 기능 추가

목록 조회 API에서 키워드 검색을 지원합니다.

검색 대상

* title
* content
* contestName
* clubName

예시

GET /api/club-collaborations?keyword=간지톤&page=0&size=10

검색 결과가 없을 경우 빈 배열을 반환합니다.

---

### 문의하기(채팅 연동)

POST /api/club-collaborations/{collabId}/apply

구현 완료했습니다.

동작 방식

1. 협업 모집글 작성자를 조회
2. 작성자와 현재 로그인 사용자의 채팅방 확인
3. 기존 채팅방이 있으면 반환
4. 없으면 새 채팅방 생성

응답 예시

```json
{
  "chatRoomId": 1,
  "collabId": 1,
  "isNew": true,
  "title": "간지톤 같이 나갈 디자이너 구해요"
}
```

---

## 테스트 완료

### 협업 모집글

* 작성 성공
* 목록 조회 성공
* 상세 조회 성공
* 수정 성공
* 삭제 성공

### 권한 검증

* STAFF 작성 가능 확인
* PRESIDENT 작성 가능 확인
* MEMBER 작성 불가 확인

### 날짜 검증

* 잘못된 마감일 예외 처리 확인
* 과거 날짜 예외 처리 확인

### 검색 기능

* 검색 성공 확인
* 검색 결과 없음 시 빈 배열 반환 확인

### 문의하기

* 신규 채팅방 생성 확인

