### PR TITLE
Feat/41 main

### DIFF
--- a/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
+++ b/src/main/java/com/skhu/skhucapstone/common/exception/SuccessCode.java
@@ -43,6 +43,9 @@ public enum SuccessCode {
     // ClubMember
     CLUB_MEMBER_LIST_GET_SUCCESS(HttpStatus.OK, "CLUB_MEMBER_LIST_GET_SUCCESS", "동아리 멤버 목록 조회가 완료되었습니다."),
 
+    //Main
+    MAIN_GET_SUCCESS(HttpStatus.OK, "MAIN_GET_SUCCESS", "메인페이지 조회가 완료되었습니다."),
+
     // 협업모집
     CLUB_COLLAB_CREATE_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_CREATE_SUCCESS", "협업 모집글 작성이 완료되었습니다."),
     CLUB_COLLAB_LIST_GET_SUCCESS(HttpStatus.OK, "CLUB_COLLAB_LIST_GET_SUCCESS", "협업 모집글 목록 조회가 완료되었습니다."),

--- a/src/main/java/com/skhu/skhucapstone/main/api/MainController.java
+++ b/src/main/java/com/skhu/skhucapstone/main/api/MainController.java
@@ -1,0 +1,31 @@
+package com.skhu.skhucapstone.main.api;
+
+import com.skhu.skhucapstone.common.exception.SuccessCode;
+import com.skhu.skhucapstone.common.response.ApiResponse;
+import com.skhu.skhucapstone.main.api.dto.response.MainResponse;
+import com.skhu.skhucapstone.main.application.MainService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/main")
+@Tag(name = "Main", description = "메인페이지 API")
+public class MainController {
+
+    private final MainService mainService;
+
+    @GetMapping
+    @Operation(
+            summary = "메인페이지 조회",
+            description = "메인페이지에 필요한 데이터를 조회합니다."
+    )
+    public ResponseEntity<ApiResponse<MainResponse>> getMainPage() {
+        MainResponse response = mainService.getMainPage();
+
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.MAIN_GET_SUCCESS, response));
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/main/api/dto/response/ClubCollabRes.java
+++ b/src/main/java/com/skhu/skhucapstone/main/api/dto/response/ClubCollabRes.java
@@ -1,0 +1,19 @@
+package com.skhu.skhucapstone.main.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ClubCollabRes {
+
+    private Long collabId;
+
+    private String title;
+
+    private String content;
+
+    private String dDayText;
+
+    private String clubName;
+}

--- a/src/main/java/com/skhu/skhucapstone/main/api/dto/response/ClubFeedRes.java
+++ b/src/main/java/com/skhu/skhucapstone/main/api/dto/response/ClubFeedRes.java
@@ -1,0 +1,24 @@
+package com.skhu.skhucapstone.main.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class ClubFeedRes {
+
+    private Long postId;
+
+    private String writerName;
+
+    private String clubName;
+
+    private LocalDateTime createdAt;
+
+    private List<String> imageUrls;
+
+    private String content;
+}

--- a/src/main/java/com/skhu/skhucapstone/main/api/dto/response/CoffeeChatRes.java
+++ b/src/main/java/com/skhu/skhucapstone/main/api/dto/response/CoffeeChatRes.java
@@ -1,0 +1,26 @@
+package com.skhu.skhucapstone.main.api.dto.response;
+
+import com.skhu.skhucapstone.coffeechat.entity.MeetingType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoffeeChatRes {
+
+    private Long coffeeChatProfileId;
+
+    private Long userId;
+
+    private String name;
+
+    private String headline;
+
+    private String interestTopics;
+
+    private List<String> clubs;
+
+    private MeetingType meetingType;
+}

--- a/src/main/java/com/skhu/skhucapstone/main/api/dto/response/MainResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/main/api/dto/response/MainResponse.java
@@ -1,0 +1,19 @@
+package com.skhu.skhucapstone.main.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MainResponse {
+
+    private List<CoffeeChatRes> recommendedCoffeeChats;
+
+    private List<ProjectRecruitRes> projectRecruitments;
+
+    private List<ClubCollabRes> clubCollaborations;
+
+    private List<ClubFeedRes> clubFeeds;
+}

--- a/src/main/java/com/skhu/skhucapstone/main/api/dto/response/ProjectRecruitRes.java
+++ b/src/main/java/com/skhu/skhucapstone/main/api/dto/response/ProjectRecruitRes.java
@@ -1,0 +1,23 @@
+package com.skhu.skhucapstone.main.api.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class ProjectRecruitRes {
+
+    private Long projectRecruitmentId;
+
+    private String title;
+
+    private String content;
+
+    private String imageUrl;
+
+    private LocalDate deadline;
+
+    private String dDay;
+}

--- a/src/main/java/com/skhu/skhucapstone/main/application/MainService.java
+++ b/src/main/java/com/skhu/skhucapstone/main/application/MainService.java
@@ -101,6 +101,7 @@ public class MainService {
 
     private ClubFeedRes toClubFeedRes(PostResponse post) {
         return ClubFeedRes.builder()
+                .clubName(post.getClubName())
                 .postId(post.getPostId())
                 .writerName(post.getWriterName())
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/com/skhu/skhucapstone/main/application/MainService.java
+++ b/src/main/java/com/skhu/skhucapstone/main/application/MainService.java
@@ -1,0 +1,111 @@
+package com.skhu.skhucapstone.main.application;
+
+import com.skhu.skhucapstone.clubcollaboration.api.dto.response.ClubCollabResponse;
+import com.skhu.skhucapstone.clubcollaboration.application.ClubCollabService;
+import com.skhu.skhucapstone.coffeechat.dto.res.CoffeeChatProfileListItemRes;
+import com.skhu.skhucapstone.coffeechat.service.CoffeeChatService;
+import com.skhu.skhucapstone.main.api.dto.response.*;
+import com.skhu.skhucapstone.post.api.dto.response.PostResponse;
+import com.skhu.skhucapstone.post.application.PostService;
+import com.skhu.skhucapstone.projectrecruitment.dto.res.ProjectRecruitmentListRes;
+import com.skhu.skhucapstone.projectrecruitment.service.ProjectRecruitmentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MainService {
+
+    private final CoffeeChatService coffeeChatService;
+    private final ProjectRecruitmentService projectRecruitmentService;
+    private final ClubCollabService clubCollabService;
+    private final PostService postService;
+
+    public MainResponse getMainPage() {
+        return MainResponse.builder()
+                .recommendedCoffeeChats(getCoffeeChats())
+                .projectRecruitments(getProjectRecruitments())
+                .clubCollaborations(getClubCollaborations())
+                .clubFeeds(getClubFeeds())
+                .build();
+    }
+
+    private List<CoffeeChatRes> getCoffeeChats() {
+        return coffeeChatService.getProfiles(null, 0, 3)
+                .getContent()
+                .stream()
+                .map(this::toCoffeeChatRes)
+                .toList();
+    }
+
+    private List<ProjectRecruitRes> getProjectRecruitments() {
+        return projectRecruitmentService.getRecruitments(null, 0, 6)
+                .getContent()
+                .stream()
+                .map(this::toProjectRecruitRes)
+                .toList();
+    }
+
+    private List<ClubCollabRes> getClubCollaborations() {
+        return clubCollabService.getCollabs(null, 0, 6)
+                .getContent()
+                .stream()
+                .map(this::toClubCollabRes)
+                .toList();
+    }
+
+    private List<ClubFeedRes> getClubFeeds() {
+        return postService.getPosts(0, 4)
+                .getContent()
+                .stream()
+                .map(this::toClubFeedRes)
+                .toList();
+    }
+
+    private CoffeeChatRes toCoffeeChatRes(CoffeeChatProfileListItemRes profile) {
+        return CoffeeChatRes.builder()
+                .coffeeChatProfileId(profile.getCoffeeChatProfileId())
+                .userId(profile.getUserId())
+                .name(profile.getName())
+                .headline(profile.getHeadline())
+                .interestTopics(profile.getInterestTopics())
+                .clubs(profile.getClubs())
+                .meetingType(profile.getMeetingType())
+                .build();
+    }
+
+    private ProjectRecruitRes toProjectRecruitRes(ProjectRecruitmentListRes recruitment) {
+        return ProjectRecruitRes.builder()
+                .projectRecruitmentId(recruitment.getProjectRecruitmentId())
+                .title(recruitment.getTitle())
+                .content(recruitment.getContent())
+                .imageUrl(recruitment.getImageUrl())
+                .deadline(recruitment.getDeadline())
+                .dDay(recruitment.getDDay())
+                .build();
+    }
+
+    private ClubCollabRes toClubCollabRes(ClubCollabResponse collab) {
+        return ClubCollabRes.builder()
+                .collabId(collab.getCollabId())
+                .title(collab.getTitle())
+                .content(collab.getContent())
+                .dDayText(collab.getDDayText())
+                .clubName(collab.getClubName())
+                .build();
+    }
+
+    private ClubFeedRes toClubFeedRes(PostResponse post) {
+        return ClubFeedRes.builder()
+                .postId(post.getPostId())
+                .writerName(post.getWriterName())
+                .createdAt(post.getCreatedAt())
+                .imageUrls(post.getImageUrls())
+                .content(post.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/skhu/skhucapstone/post/api/PostController.java
+++ b/src/main/java/com/skhu/skhucapstone/post/api/PostController.java
@@ -38,15 +38,31 @@ public class PostController {
     }
 
     @GetMapping("/posts")
-    @Operation(summary = "전체 게시글 조회", description = "전체 동아리 게시글을 페이지 단위로 조회합니다.")
+    @Operation(
+            summary = "전체 게시글 조회",
+            description = "전체 동아리 게시글을 최신순 또는 좋아요순으로 조회합니다."
+    )
     public ResponseEntity<ApiResponse<PostPageResponse>> getPosts(
+
+            @RequestParam(defaultValue = "latest") String sort,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "4") int size
+
     ) {
-        PostPageResponse response = postService.getPosts(page, size);
+
+        PostPageResponse response;
+
+        if ("likes".equals(sort)) {
+            response = postService.getRecommendedPosts(page, size);
+        } else {
+            response = postService.getPosts(page, size);
+        }
 
         return ResponseEntity.ok(
-                ApiResponse.success(SuccessCode.POST_LIST_GET_SUCCESS, response)
+                ApiResponse.success(
+                        SuccessCode.POST_LIST_GET_SUCCESS,
+                        response
+                )
         );
     }
 

--- a/src/main/java/com/skhu/skhucapstone/post/api/dto/response/PostResponse.java
+++ b/src/main/java/com/skhu/skhucapstone/post/api/dto/response/PostResponse.java
@@ -12,6 +12,8 @@ import java.time.LocalDateTime;
 @Builder
 public class PostResponse {
 
+    private String clubName;
+
     private Long postId;
 
     private String title;

--- a/src/main/java/com/skhu/skhucapstone/post/application/PostService.java
+++ b/src/main/java/com/skhu/skhucapstone/post/application/PostService.java
@@ -191,6 +191,7 @@ public class PostService {
                 .toList();
 
         return PostResponse.builder()
+                .clubName(post.getClub().getClubName())
                 .postId(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())

--- a/src/main/java/com/skhu/skhucapstone/post/application/PostService.java
+++ b/src/main/java/com/skhu/skhucapstone/post/application/PostService.java
@@ -200,4 +200,24 @@ public class PostService {
                 .createdAt(post.getCreatedAt())
                 .build();
     }
+
+    public PostPageResponse getRecommendedPosts(int page, int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<Post> posts =
+                postRepository.findAllOrderByLikeCountDesc(pageable);
+
+        return PostPageResponse.builder()
+                .content(posts.getContent()
+                        .stream()
+                        .map(this::toPostResponse)
+                        .toList())
+                .page(posts.getNumber())
+                .size(posts.getSize())
+                .totalElements(posts.getTotalElements())
+                .totalPages(posts.getTotalPages())
+                .last(posts.isLast())
+                .build();
+    }
 }

--- a/src/main/java/com/skhu/skhucapstone/post/domain/repository/PostRepository.java
+++ b/src/main/java/com/skhu/skhucapstone/post/domain/repository/PostRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -20,4 +21,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     Page<Post> findByClubOrderByCreatedAtDesc(Club club, Pageable pageable);
+
+    @Query("""
+    SELECT p
+    FROM Post p
+    LEFT JOIN Likes l ON l.post = p
+    GROUP BY p
+    ORDER BY COUNT(l) DESC, p.createdAt DESC
+    """)
+    Page<Post> findAllOrderByLikeCountDesc(Pageable pageable);
 }


### PR DESCRIPTION
# feat/41-main PR

## 작업 내용

### 메인페이지 조회 API 구현

`GET /api/main`

메인페이지에 필요한 데이터를 한 번에 조회할 수 있도록 API를 구현했습니다.

조회 항목

* 커피챗
* 프로젝트 모집
* 동아리 협업 모집
* 전체 동아리 피드

---

### 게시글 좋아요순 조회 기능 추가

기존 최신순 조회만 가능했던 게시글 목록 조회 API에 좋아요순 조회 기능을 추가했습니다.

```http
GET /api/posts?sort=latest
GET /api/posts?sort=likes
```

정렬 기준

* latest : 최신순
* likes : 좋아요순
* 좋아요 수가 같을 경우 최신 게시글 우선

---

### 게시글 응답 개선

기존 게시글 응답에 동아리명이 포함되지 않아 메인페이지에서 동아리명을 표시할 수 없었습니다.

게시글 응답 DTO에 clubName을 추가하여 메인페이지에서 동아리명을 함께 조회할 수 있도록 수정했습니다.

---

## 테스트 완료

### 메인페이지 조회

```http
GET /api/main
```

확인 항목

* 동아리 협업 모집 조회
* 프로젝트 모집 조회
* 추천 커피챗 조회
* 동아리 피드 조회

---

### 게시글 조회

최신순

```http
GET /api/posts
```

또는

```http
GET /api/posts?sort=latest
```

좋아요순

```http
GET /api/posts?sort=likes
```

정상 동작 확인 완료

---

## 참고

현재 메인페이지의 데이터 노출 순서는 최신순 기준입니다.

랜덤 노출은 프론트엔드에서 처리하기로 논의되어 백엔드에서는 최신 데이터만 제공합니다.
